### PR TITLE
Foreign Endianess

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "goblin"
 version = "0.0.1"
-authors = ["m4b <m4b.github.io@gmail.com>"]
+authors = ["m4b <m4b.github.io@gmail.com>", "seu <seu@panopticon.re>"]
 readme = "README.md"
 keywords = ["binary", "elf", "mach", "pe", "cross-platform"]
 repository = "https://github.com/m4b/goblin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goblin"
-version = "0.0.0"
+version = "0.0.1"
 authors = ["m4b <m4b.github.io@gmail.com>"]
 readme = "README.md"
 keywords = ["binary", "elf", "mach", "pe", "cross-platform"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,12 @@ description = "An impish, cross-platform binary parsing and loading crate"
 [lib]
 crate-type = ["rlib", "dylib"]
 
+[dependencies.byteorder]
+version = "0.5"
+optional = true
+
 [features]
-default = []
+default = ["byteorder"]
 no_elf32 = []
 no_elf = []
 no_mach = []
@@ -20,3 +24,4 @@ no_mach32 = []
 no_pe = []
 no_pe32 = []
 no_goblin = []
+no_endian_fd = []

--- a/src/elf/header.rs
+++ b/src/elf/header.rs
@@ -76,9 +76,23 @@ impl Header {
         header.clone()
     }
 
+#[cfg(not(feature = "no_endian_fd"))]
+    pub fn from_fd(fd: &mut File) -> io::Result<Header> {
+        let mut elf_header = [0; EHDR_SIZE];
+        use std::io::Cursor;
+        use byteorder::{BigEndian, ReadBytesExt};
+        let mut rdr = Cursor::new(vec![2, 5, 3, 0]);
+        assert_eq!(517, rdr.read_u16::<BigEndian>().unwrap());
+        assert_eq!(768, rdr.read_u16::<BigEndian>().unwrap());
+        try!(fd.read(&mut elf_header));
+        Ok(Header::from_bytes(&elf_header))
+    }
+
+#[cfg(feature = "no_endian_fd")]
     pub fn from_fd(fd: &mut File) -> io::Result<Header> {
         let mut elf_header = [0; EHDR_SIZE];
         try!(fd.read(&mut elf_header));
         Ok(Header::from_bytes(&elf_header))
     }
+
 }

--- a/src/elf/sym.rs
+++ b/src/elf/sym.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use std::slice;
 
 #[repr(C)]
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Default)]
 pub struct Sym {
     pub st_name: u32, // Symbol name (string tbl index)
     pub st_info: u8, // Symbol type and binding
@@ -115,7 +115,40 @@ pub unsafe fn from_raw<'a>(symp: *const Sym, count: usize) -> &'a [Sym] {
     slice::from_raw_parts(symp, count)
 }
 
-pub fn from_fd<'a>(fd: &mut File, offset: usize, count: usize) -> io::Result<Vec<Sym>> {
+#[cfg(not(feature = "no_endian_fd"))]
+pub fn from_fd<'a>(fd: &mut File, offset: usize, count: usize, is_lsb: bool) -> io::Result<Vec<Sym>> {
+    use byteorder::{LittleEndian,BigEndian,ReadBytesExt};
+    let mut syms = Vec::with_capacity(count);
+
+    try!(fd.seek(Start(offset as u64)));
+    for _ in 0..count {
+        let mut sym = Sym::default();
+
+        if is_lsb {
+            sym.st_name = try!(fd.read_u32::<LittleEndian>());
+            sym.st_info = try!(try!(fd.bytes().next().ok_or(io::Error::new(io::ErrorKind::UnexpectedEof, ""))));
+            sym.st_other = try!(try!(fd.bytes().next().ok_or(io::Error::new(io::ErrorKind::UnexpectedEof, ""))));
+            sym.st_shndx = try!(fd.read_u16::<LittleEndian>());
+            sym.st_value = try!(fd.read_u64::<LittleEndian>());
+            sym.st_size = try!(fd.read_u64::<LittleEndian>());
+        } else {
+            sym.st_name = try!(fd.read_u32::<BigEndian>());
+            sym.st_info = try!(try!(fd.bytes().next().ok_or(io::Error::new(io::ErrorKind::UnexpectedEof, ""))));
+            sym.st_other = try!(try!(fd.bytes().next().ok_or(io::Error::new(io::ErrorKind::UnexpectedEof, ""))));
+            sym.st_shndx = try!(fd.read_u16::<BigEndian>());
+            sym.st_value = try!(fd.read_u64::<BigEndian>());
+            sym.st_size = try!(fd.read_u64::<BigEndian>());
+        }
+
+        syms.push(sym);
+    }
+
+    syms.dedup();
+    Ok(syms)
+}
+
+#[cfg(feature = "no_endian_fd")]
+pub fn from_fd<'a>(fd: &mut File, offset: usize, count: usize, _: bool) -> io::Result<Vec<Sym>> {
     let mut bytes = vec![0u8; count * SIZEOF_SYM]; // afaik this shouldn't work, since i pass in a byte size...
     try!(fd.seek(Start(offset as u64)));
     try!(fd.read(&mut bytes));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "no_endian_fd"))]
+extern crate byteorder;
+
 // for now only switches on elf 64 bit variants; need to figure that out
 // do _not_ want namespaced elf::elf64::header nonsense, just want
 // this kind of nonsense: elf::header32

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+// if the no_endian feature flag is set the libary will only be able to
+// process files with the same endianess as the machine.
 #[cfg(not(feature = "no_endian_fd"))]
 extern crate byteorder;
 


### PR DESCRIPTION
Extends the `from_fd` functions to consider the byte order of all integers in the ELF file. Adds a dependency to the `byteorder` crate.