### PR TITLE
Mostly style improvements & criticism

### DIFF
--- a/src/elf/_32/dyn.rs
+++ b/src/elf/_32/dyn.rs
@@ -2,8 +2,8 @@ pub use super::super::elf::dyn::*;
 
 #[derive(Copy, Clone, PartialEq, Default)]
 pub struct Dyn {
-  pub d_tag: u32, // Dynamic entry type
-  pub d_val: u32, // Integer value
+    pub d_tag: u32, // Dynamic entry type
+    pub d_val: u32, // Integer value
 }
 
 pub const SIZEOF_DYN: usize = 8;

--- a/src/elf/_32/mod.rs
+++ b/src/elf/_32/mod.rs
@@ -12,5 +12,5 @@ pub use self::impure::*;
 
 #[cfg(not(feature = "pure"))]
 mod impure {
-    elf_from_fd!(::std::u32::MAX);
+    elf_from_fd!(!0);
 }

--- a/src/elf/_32/rela.rs
+++ b/src/elf/_32/rela.rs
@@ -61,4 +61,3 @@ elf_rela_impure_impl!(
         res.dedup();
         Ok(res)
     });
-

--- a/src/elf/_32/section_header.rs
+++ b/src/elf/_32/section_header.rs
@@ -4,16 +4,16 @@ pub use super::super::elf::section_header::*;
 #[derive(Clone, PartialEq, Default)]
 #[cfg_attr(not(feature = "pure"), derive(Debug))]
 pub struct SectionHeader {
-  sh_name: u32,	// Section name (string tbl index)
-  sh_type: u32,	// Section type
-  sh_flags: u32, // Section flags
-  sh_addr: u32,	// Section virtual addr at execution
-  sh_offset: u32, // Section file offset
-  sh_size: u32,	// Section size in bytes
-  sh_link: u32,	// Link to another section
-  sh_info: u32,	// Additional section information
-  sh_addralign: u32, // Section alignment
-  sh_entsize: u32, // Entry size if section holds table
+    sh_name: u32, // Section name (string tbl index)
+    sh_type: u32, // Section type
+    sh_flags: u32, // Section flags
+    sh_addr: u32, // Section virtual addr at execution
+    sh_offset: u32, // Section file offset
+    sh_size: u32, // Section size in bytes
+    sh_link: u32, // Link to another section
+    sh_info: u32, // Additional section information
+    sh_addralign: u32, // Section alignment
+    sh_entsize: u32, // Entry size if section holds table
 }
 
 pub const SIZEOF_SHDR: usize = 40;

--- a/src/elf/_64/rela.rs
+++ b/src/elf/_64/rela.rs
@@ -93,4 +93,3 @@ elf_rela_impure_impl!(
         res.dedup();
         Ok(res)
     });
-

--- a/src/elf/strtab.rs
+++ b/src/elf/strtab.rs
@@ -26,7 +26,9 @@ fn get_str(idx: usize, bytes: &[u8]) -> &str {
         i += 1;
     }
     // we drop the null terminator unless we're at the end and the byte isn't a null terminator
-    if i < len || bytes[i-1] == 0 { i -= 1; }
+    if i < len || bytes[i - 1] == 0 {
+        i -= 1;
+    }
     str::from_utf8(&bytes[idx..i]).unwrap()
 }
 
@@ -82,7 +84,7 @@ impl<'a> Strtab<'a> {
 #[test]
 fn as_vec_test_no_final_null() {
     let bytes = b"\0printf\0memmove\0busta";
-    let strtab = unsafe { Strtab::from_raw (bytes.as_ptr(), bytes.len()) };
+    let strtab = unsafe { Strtab::from_raw(bytes.as_ptr(), bytes.len()) };
     let vec = strtab.to_vec();
     assert_eq!(vec.len(), 4);
 }
@@ -90,7 +92,7 @@ fn as_vec_test_no_final_null() {
 #[test]
 fn to_vec_test_final_null() {
     let bytes = b"\0printf\0memmove\0busta\0";
-    let strtab = unsafe { Strtab::from_raw (bytes.as_ptr(), bytes.len()) };
+    let strtab = unsafe { Strtab::from_raw(bytes.as_ptr(), bytes.len()) };
     let vec = strtab.to_vec();
     assert_eq!(vec.len(), 4);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,27 @@
 //! # libGoblin
-//! ![say the right words](https://s-media-cache-ak0.pinimg.com/736x/1b/6a/aa/1b6aaa2bae005e2fed84b1a7c32ecb1b.jpg)
 //!
-//! `libgoblin` is a cross-platform trifecta of binary parsing and loading fun.
-//! Currently, it only supports the ELF format, in both 32-bit and 64-bit variants (with especial bias towards 64-bit formats).
-//! The mach parser is in progress, and the PE format will follow.
-//! `libgoblin` is engineered to be tailored towards very different use-case scenarios, for example:
+//! ![say the right
+//! words](https://s-media-cache-ak0.pinimg.com/736x/1b/6a/aa/1b6aaa2bae005e2fed84b1a7c32ecb1b.jpg)
 //!
-//! * a "pure" mode which includes no io, no std, and no fun!
-//! * a non-endian fd reading mode (which reads in the host machines endianness, for loaders)
-//! * cfg switches to turn off unused binary formats (when relocation and binary size are important (ideally, in the future this won't be necessary if the compiler and/or linker can guarantee the unused symbols are dropped in the final artifact)
+//! `libgoblin` is a cross-platform trifecta of binary parsing and loading fun.  Currently, it only
+//! supports the ELF format, in both 32-bit and 64-bit variants (with especial bias towards 64-bit
+//! formats).  The mach parser is in progress, and the PE format will follow.  `libgoblin` is
+//! engineered to be tailored towards very different use-case scenarios, for example:
 //!
-//! # Using the features
-//! For example, if you are writing a kernel, or just want a barebones C-like header interface which defines the structures, enable the pure feature, `--cfg feature=\"pure\"`, which will turn off `std` and remove all extra methods defined on the structs.
+//! * a "pure" mode which includes no io, no std, and no fun!  * a non-endian fd reading mode
+//! (which reads in the host machines endianness, for loaders) * cfg switches to turn off unused
+//! binary formats (when relocation and binary size are important (ideally, in the future this
+//! won't be necessary if the compiler and/or linker can guarantee the unused symbols are dropped
+//! in the final artifact)
 //!
-//! Similarly, if you want to use host endianness loading via the various `from_fd` methods, `--cfg feature=\"no_endian_fd\"`, which will not use the `byteorder` extern crate, and read the bytes from disk in the endianness of the host machine.
+//! # Using the features For example, if you are writing a kernel, or just want a barebones C-like
+//! header interface which defines the structures, enable the pure feature, `--cfg
+//! feature=\"pure\"`, which will turn off `std` and remove all extra methods defined on the
+//! structs.
+//!
+//! Similarly, if you want to use host endianness loading via the various `from_fd` methods, `--cfg
+//! feature=\"no_endian_fd\"`, which will not use the `byteorder` extern crate, and read the bytes
+//! from disk in the endianness of the host machine.
 
 #![cfg_attr(feature = "pure", no_std)]
 
@@ -22,18 +30,25 @@
 #[cfg(not(feature = "no_endian_fd"))]
 extern crate byteorder;
 
-#[macro_use] mod macros;
+#[macro_use]
+mod macros;
 
 #[cfg(any(not(feature = "no_elf"), not(feature = "no_elf32")))]
-#[macro_use] pub mod elf;
+#[macro_use]
+pub mod elf;
 
-// if racer gets path understanding, i think this is the way to go; it hides everything from the user w.r.t. module internals like _64, etc.
-// though i did like the more declarative version below, without using paths, i just for the life of me cannot get the compiler to reexport values two mods down while keeping the internal mod name private... and i don't see anyone else doing this
+// if racer gets path understanding, i think this is the way to go; it hides everything from the
+// user w.r.t. module internals like _64, etc.  though i did like the more declarative version
+// below, without using paths, i just for the life of me cannot get the compiler to reexport values
+// two mods down while keeping the internal mod name private... and i don't see anyone else doing
+// this
 #[cfg(not(feature = "no_elf"))]
-#[path = "elf/_64/mod.rs"] pub mod elf64;
+#[path = "elf/_64/mod.rs"]
+pub mod elf64;
 
 #[cfg(not(feature = "no_elf32"))]
-#[path = "elf/_32/mod.rs"] pub mod elf32;
+#[path = "elf/_32/mod.rs"]
+pub mod elf32;
 
 #[cfg(not(feature = "no_mach"))]
 pub mod mach;

--- a/src/mach/fat.rs
+++ b/src/mach/fat.rs
@@ -5,7 +5,7 @@ use std::io::{self, Read, Seek};
 use std::io::SeekFrom::Start;
 use super::constants::cputype;
 
-use byteorder::{BigEndian,ReadBytesExt};
+use byteorder::{BigEndian, ReadBytesExt};
 
 pub const FAT_MAGIC: u32 = 0xcafebabe;
 pub const FAT_CIGAM: u32 = 0xbebafeca;
@@ -56,7 +56,10 @@ impl FatHeader {
         let mut cursor = Cursor::new(bytes);
         let magic = cursor.read_u32::<BigEndian>().unwrap();
         let nfat_arch = cursor.read_u32::<BigEndian>().unwrap();
-        FatHeader { magic: magic, nfat_arch: nfat_arch }
+        FatHeader {
+            magic: magic,
+            nfat_arch: nfat_arch,
+        }
     }
 
     pub fn from_fd(fd: &mut File) -> io::Result<FatHeader> {
@@ -67,7 +70,6 @@ impl FatHeader {
 }
 
 impl FatArch {
-
     pub fn new(bytes: &[u8; SIZEOF_FAT_ARCH]) -> FatArch {
         use std::io::Cursor;
         let mut cursor = Cursor::new(bytes);
@@ -76,7 +78,13 @@ impl FatArch {
         let offset = cursor.read_u32::<BigEndian>().unwrap();
         let size = cursor.read_u32::<BigEndian>().unwrap();
         let align = cursor.read_u32::<BigEndian>().unwrap();
-        FatArch {cputype: cputype, cpusubtype: cpusubtype, offset: offset, size: size, align: align}
+        FatArch {
+            cputype: cputype,
+            cpusubtype: cpusubtype,
+            offset: offset,
+            size: size,
+            align: align,
+        }
     }
 
     pub fn is_64(&self) -> bool {
@@ -106,10 +114,10 @@ impl FatArch {
     }
 
     pub fn find_cputype(arches: &[Self], cputype: u32) -> Option<&Self> {
-        arches.iter().find(| arch | arch.cputype == cputype)
+        arches.iter().find(|arch| arch.cputype == cputype)
     }
 
     pub fn find_64(arches: &[Self]) -> Option<&Self> {
-        arches.iter().find(| arch | arch.is_64())
+        arches.iter().find(|arch| arch.is_64())
     }
 }

--- a/src/mach/header.rs
+++ b/src/mach/header.rs
@@ -39,7 +39,7 @@ pub const MH_NO_HEAP_EXECUTION: u32 = 0x1000000; // When this bit is set, the OS
 pub const MH_APP_EXTENSION_SAFE: u32 = 0x2000000; // The code was linked for use in an application extension.
 
 #[inline(always)]
-pub fn  flag_to_str(flag: u32) -> &'static str {
+pub fn flag_to_str(flag: u32) -> &'static str {
     match flag {
         MH_NOUNDEFS => "MH_NOUNDEFS",
         MH_INCRLINK => "MH_INCRLINK",
@@ -52,7 +52,7 @@ pub fn  flag_to_str(flag: u32) -> &'static str {
         MH_FORCE_FLAT => "MH_FORCE_FLAT",
         MH_NOMULTIDEFS => "MH_NOMULTIDEFS",
         MH_NOFIXPREBINDING => "MH_NOFIXPREBINDING",
-        MH_PREBINDABLE  => "MH_PREBINDABLE ",
+        MH_PREBINDABLE => "MH_PREBINDABLE ",
         MH_ALLMODSBOUND => "MH_ALLMODSBOUND",
         MH_SUBSECTIONS_VIA_SYMBOLS => "MH_SUBSECTIONS_VIA_SYMBOLS",
         MH_CANONICAL => "MH_CANONICAL",
@@ -67,7 +67,7 @@ pub fn  flag_to_str(flag: u32) -> &'static str {
         MH_HAS_TLV_DESCRIPTORS => "MH_HAS_TLV_DESCRIPTORS",
         MH_NO_HEAP_EXECUTION => "MH_NO_HEAP_EXECUTION",
         MH_APP_EXTENSION_SAFE => "MH_APP_EXTENSION_SAFE",
-        _ => "UNKNOWN FLAG"
+        _ => "UNKNOWN FLAG",
     }
 }
 
@@ -147,12 +147,11 @@ impl Header {
         *header
     }
 
-    //#[cfg(feature = "no_endian_fd")]
+    // #[cfg(feature = "no_endian_fd")]
     pub fn from_fd(fd: &mut File, offset: u64) -> io::Result<Header> {
         let mut header = [0; SIZEOF_MACH_HEADER];
         try!(fd.seek(Start(offset)));
         try!(fd.read(&mut header));
         Ok(Header::from_bytes(&header))
     }
-
 }

--- a/src/mach/utils.rs
+++ b/src/mach/utils.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 use std::io;
 
-use byteorder::{LittleEndian,ReadBytesExt};
+use byteorder::{LittleEndian, ReadBytesExt};
 
 /// Returns a little endian magical number; be careful as this will alter the seek on the `fd`
 pub fn peek_magic(fd: &mut File) -> io::Result<u32> {


### PR DESCRIPTION
This tries to make the style more aligned to idiomatic Rust.

----

Very nice crate, indeed (Redox's ELF parser was getting unmaintainable anyway)!

If you don't mind, I have a some criticism, mostly idiomatic ones.

1. So, you seem to be writing Rust the same way you would write C. You would make everything much cleaner if you made more use of Rust's type system and other abstractions.

   1. Use the enum! You make use of the constant integer approach. Unfortunately, this makes code somewhat hairy. You could eliminate classes of bugs as well as writing more clean and idiomatic Rust code, if you made more use of enums. One particularly handy features is the ability to define the discriminant and then cast it to an integer (`my_enum_value as u8`). Instead of the 100 lines of constant declaration, make an enum.

   2. Newtyping. Byte strings are naturally untyped, newtyping makes sure that you do not accidentally do bad stuff. Furthermore, you are then able to define the needed methods directly on the type.

   3. Traits. So, there are a lot of places where you use standalone functions to implement functionality which could be provided by a trait implementation (for example, all of those `a_to_str` methods are unneeded in favor of the `Display` or `From` trait).

   4. Less lonely functions. Lonely functions are generally considered an anti-pattern in Rust, especially if they ties to some specific type, which it seems that yours often do.

   5. Macros. You reimplement a lot of the same stuff, which could be reduced to only a single implementation through macros.

   6. Generics. I see afew places where generics are useful.

2. Your documentation is pretty good. The only catch is the way you document it. Instead of using `//` comments, you should use `///` comments, which allows it to be rendered in the API docs.

3. Certain style choices in this crate are inconsistent with conventional Rust:

   1. I recommend running the `rustfmt` utility over the codebase, it makes the style more uniform.

   2. Some modules are unnecessarily big without any strong relation between the primitives provided. These could be broken down.

    3. `inline(always)` is generally considered bad, since `inline` gives the compiler more freedom, which means better performance.

    4. Long lists of variables. I noticed a few places where a lot of variables were declared, despite the fact that all of those could be packed into a struct. Things like `derive(Default)` are very useful here.

    5. `clippy` is fairly good at detecting anti-patterns.

I hope that wasn't too nitpicky.

Nice crate, and keep it up.
