### PR TITLE
Replace unsafe bits using crate `plain`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ documentation = "https://docs.rs/goblin"
 
 [lib]
 
+[dependencies]
+plain = "0.0.2"
+
 [dependencies.scroll]
 version = "0.4.0"
 default_features = false

--- a/src/elf/header.rs
+++ b/src/elf/header.rs
@@ -36,13 +36,17 @@ macro_rules! elf_header {
             /// Section header string table index
             pub e_shstrndx: u16,
         }
+
+        use plain;
+        // Declare that this is a plain type.
+        unsafe impl plain::Plain for Header {}
+
         impl Header {
             /// Returns the corresponding ELF header from the given byte array.
             pub fn from_bytes(bytes: &[u8; SIZEOF_EHDR]) -> &Header {
-                // This is not unsafe because the header's size is encoded in the function,
-                // although the header can be semantically invalid.
-                let header: &Header = unsafe { ::core::mem::transmute(bytes) };
-                header
+                // FIXME: Length is ensured correct because it's encoded in the type,
+                // but it can still panic due to invalid alignment.
+                plain::from_bytes(bytes).unwrap()
             }
         }
         impl fmt::Debug for Header {

--- a/src/elf/sym.rs
+++ b/src/elf/sym.rs
@@ -126,6 +126,7 @@ macro_rules! elf_sym_std_impl {
             use elf::error::*;
 
             use core::fmt;
+            use core::slice;
 
             use std::fs::File;
             use std::io::{Read, Seek};
@@ -187,11 +188,16 @@ macro_rules! elf_sym_std_impl {
                 }
             }
 
+            pub unsafe fn from_raw<'a>(symp: *const Sym, count: usize) -> &'a [Sym] {
+                 slice::from_raw_parts(symp, count)
+            }
+
             pub fn from_fd<'a>(fd: &mut File, offset: usize, count: usize) -> Result<Vec<Sym>> {
                 // TODO: AFAIK this shouldn't work, since i pass in a byte size...
                 let mut syms = vec![Sym::default(); count];
                 try!(fd.seek(Start(offset as u64)));
                 try!(fd.read(syms.as_mut_bytes()));
+                syms.dedup();
                 Ok(syms)
             }
 

--- a/src/elf/sym.rs
+++ b/src/elf/sym.rs
@@ -189,7 +189,7 @@ macro_rules! elf_sym_std_impl {
             }
 
             pub unsafe fn from_raw<'a>(symp: *const Sym, count: usize) -> &'a [Sym] {
-                 slice::from_raw_parts(symp, count)
+                slice::from_raw_parts(symp, count)
             }
 
             pub fn from_fd<'a>(fd: &mut File, offset: usize, count: usize) -> Result<Vec<Sym>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+extern crate plain;
 extern crate scroll;
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
Wrapped in a separate tiny crate this time, because it's just that bit of functionality that totally should be in core. It is possible to go one step further and implement #[derive(Plain)], with static checking of the prescribed requirements, but I'm not yet guru enough to do that.