### PR TITLE
Rust 1.16 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: rust
 rust:
+  - 1.16.0
   - stable
   - beta
   - nightly

--- a/examples/dyldinfo.rs
+++ b/examples/dyldinfo.rs
@@ -99,11 +99,11 @@ fn print_lazy_binds(sections: &[mach::segment::Section], imports: &[mach::import
             .unwrap_or((Cow::Borrowed("?"), Cow::Borrowed("?")));
 
         println!(
-        "{:7} {:16} 0x{:<8X} 0x{:<04X} {:16} {}",
+        "{:7} {:16} 0x{:<8X} {:<06} {:16} {}",
             segname,
             sectname,
             import.address,
-            import.start_of_sequence_offset,
+            format!("0x{:04X}", import.start_of_sequence_offset),
             dylib_name(import.dylib),
             import.name
         );

--- a/src/mach/mod.rs
+++ b/src/mach/mod.rs
@@ -276,7 +276,7 @@ impl<'a> MultiArch<'a> {
         Ok(MachO::parse(bytes, 0)?)
     }
 
-    pub fn find<F: (Fn(error::Result<fat::FatArch>) -> bool)>(&'a self, f: F) -> Option<error::Result<MachO<'a>>> {
+    pub fn find<F: Fn(error::Result<fat::FatArch>) -> bool>(&'a self, f: F) -> Option<error::Result<MachO<'a>>> {
         for (i, arch) in self.iter_arches().enumerate() {
             if f(arch) {
                 return Some(self.get(i));

--- a/src/pe/debug.rs
+++ b/src/pe/debug.rs
@@ -111,10 +111,10 @@ impl<'a> CodeviewPDB70DebugInfo<'a> {
         let filename = &bytes[offset..offset + filename_length];
 
         Ok(Some(CodeviewPDB70DebugInfo{
-            codeview_signature,
-            signature,
-            age,
-            filename,
+            codeview_signature: codeview_signature,
+            signature: signature,
+            age: age,
+            filename: filename,
         }))
     }
 }

--- a/tests/compare_dyldinfos.rs
+++ b/tests/compare_dyldinfos.rs
@@ -18,10 +18,10 @@ fn compare(args: Vec<&str>) {
         .expect("run cargo dyldinfo");
 
     if apple.stdout.as_slice() != goblin.stdout.as_slice() {
-        eprintln!("dyldinfo calls disagree!");
-        eprintln!("Apple dyldinfo {:?} output:\n{}", &args, String::from_utf8_lossy(&apple.stdout));
-        eprintln!("---");
-        eprintln!("cargo dyldinfo {:?} output:\n{}", &args, String::from_utf8_lossy(&goblin.stdout));
+        println!("dyldinfo calls disagree!");
+        println!("Apple dyldinfo {:?} output:\n{}", &args, String::from_utf8_lossy(&apple.stdout));
+        println!("---");
+        println!("cargo dyldinfo {:?} output:\n{}", &args, String::from_utf8_lossy(&goblin.stdout));
         panic!("Apple dyldinfo and cargo dyldinfo differed (args: {:?})", args);
     }
 }


### PR DESCRIPTION
This PR includes some fixes for Rust 1.16. (These are mostly things I broke, except for the `Fn` in `src/mach/mod.rs`.) It also expands the Travis build matrix to include 1.16 to avoid future regressions.