### PR TITLE
Re-work Mach entrypoints

### DIFF
--- a/src/mach/mod.rs
+++ b/src/mach/mod.rs
@@ -24,7 +24,6 @@ pub fn peek(bytes: &[u8], offset: usize) -> error::Result<u32> {
     Ok(bytes.pread_with::<u32>(offset, scroll::BE)?)
 }
 
-#[derive(Debug)]
 /// A cross-platform, zero-copy, endian-aware, 32/64 bit Mach-o binary parser
 pub struct MachO<'a> {
     /// The mach-o header
@@ -49,6 +48,25 @@ pub struct MachO<'a> {
     ctx: container::Ctx,
     export_trie: Option<exports::ExportTrie<'a>>,
     bind_interpreter: Option<imports::BindInterpreter<'a>>,
+}
+
+#[cfg(feature = "std")]
+impl<'a> fmt::Debug for MachO<'a> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("MachO")
+            .field("header",        &self.header)
+            .field("load_commands", &self.load_commands)
+            .field("segments",      &self.segments)
+            .field("entry",         &self.entry)
+            .field("libs",          &self.libs)
+            .field("name",          &self.name)
+            .field("little_endian", &self.little_endian)
+            .field("is_64",         &self.is_64)
+            .field("symbols",       &self.symbols().collect::<Vec<_>>())
+            .field("exports",       &self.exports().unwrap())
+            .field("imports",       &self.imports().unwrap())
+            .finish()
+    }
 }
 
 impl<'a> MachO<'a> {

--- a/src/mach/mod.rs
+++ b/src/mach/mod.rs
@@ -52,7 +52,7 @@ pub struct MachO<'a> {
     /// The mach-o header
     pub header: header::Header,
     /// The load commands tell the kernel and dynamic linker how to use/interpret this binary
-    pub load_commands: Vec<load_command::LoadCommand<'a>>,
+    pub load_commands: Vec<load_command::LoadCommand>,
     /// The load command "segments" - typically the pieces of the binary that are loaded into memory
     pub segments: segment::Segments<'a>,
     /// The "Nlist" style symbols in this binary - strippable

--- a/src/mach/mod.rs
+++ b/src/mach/mod.rs
@@ -65,9 +65,9 @@ impl<'a> fmt::Debug for MachO<'a> {
             .field("name",            &self.name)
             .field("little_endian",   &self.little_endian)
             .field("is_64",           &self.is_64)
-            .field("symbols",         &self.symbols().collect::<Vec<_>>())
-            .field("exports",         &self.exports().unwrap())
-            .field("imports",         &self.imports().unwrap())
+            .field("symbols()",       &self.symbols().collect::<Vec<_>>())
+            .field("exports()",       &self.exports())
+            .field("imports()",       &self.imports())
             .finish()
     }
 }

--- a/src/mach/segment.rs
+++ b/src/mach/segment.rs
@@ -328,8 +328,9 @@ impl<'a> fmt::Debug for Segment<'a> {
             .field("nsects", &self.nsects)
             .field("flags", &self.flags)
             .field("data", &self.data.len())
-            .field("sections", &self.sections().unwrap()
-                .into_iter().map(|(section,_)| section).collect::<Vec<_>>())
+            .field("sections()", &self.sections().map(|sections|
+                sections.into_iter().map(|(section,_)| section).collect::<Vec<_>>())
+            )
             .finish()
     }
 }

--- a/src/mach/segment.rs
+++ b/src/mach/segment.rs
@@ -328,7 +328,8 @@ impl<'a> fmt::Debug for Segment<'a> {
             .field("nsects", &self.nsects)
             .field("flags", &self.flags)
             .field("data", &self.data.len())
-            .field("sections", &self.sections().unwrap())
+            .field("sections", &self.sections().unwrap()
+                .into_iter().map(|(section,_)| section).collect::<Vec<_>>())
             .finish()
     }
 }


### PR DESCRIPTION
This is a stab at #29. Highlights:

* `ThreadCommand` now holds a `pub thread_state: &'a [u8]`. This required plumbing `<'a>` down through `CommandVariant` and `LoadCommand`, but should permit `ThreadCommand` to be round-tripped in a way that's faithful to the original bits.
* `ThreadCommand::instruction_pointer(cputype: CpuType)` can fish out a `u64` from `thread_state`. Unfortunately, the `flavor` in the load command doesn't actually specify anything useful here -- we really do need the `cputype` from the Mach header to fish out the right register. I've verified that it works for i386 and x86-64 binaries, and I wrote handlers for ARM though I don't have any binaries with which to test.
* The earlier issue discussed making the `LC_MAIN`/`LC_UNIXTHREAD` distinction a flag, but while implementing this, I realized that the commands actually describe two different kinds of values. I made `pub entry: u64` into `pub entry: Entrypoint`, which is one of `Entrypoint::None`, `Entrypoint::Offset(u64)`, or `Entrypoint::VirtualAddress(u64)`.

Also included: `Debug` output for Mac was printing `&[u8]`s containing the data of each section as well as the data of the entire `MachO`. This made `cargo run --example rdr` difficult to use.