### PR TITLE
Remove the last Strings from Archive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,8 @@ os:
 matrix:
   allow_failures:
     - rust: nightly
+
+script:
+  - cargo build --verbose
+  - cargo test --verbose
+  - cargo build --no-default-features

--- a/src/strtab.rs
+++ b/src/strtab.rs
@@ -93,6 +93,9 @@ impl<'a> Index<usize> for Strtab<'a> {
     /// **NB**: this will panic if the underlying bytes are not valid utf8, or the offset is invalid
     #[inline(always)]
     fn index(&self, offset: usize) -> &Self::Output {
+        // This can't delegate to get() because get() requires #[cfg(features = "std")]
+        // It's also slightly less useful than get() because the lifetime -- specified by the Index
+        // trait -- matches &self, even though we could return &'a instead
         get_str(offset, &self.bytes, self.delim).unwrap()
     }
 }

--- a/tests/archive.rs
+++ b/tests/archive.rs
@@ -81,7 +81,7 @@ fn parse_self() {
         .next()
         .expect("goblin-<hash>.0.o not found");
 
-    let bytes = archive.extract(goblin_object_name.as_str(), &buffer).expect("extract goblin object");
+    let bytes = archive.extract(goblin_object_name, &buffer).expect("extract goblin object");
     match goblin::parse(&bytes).expect("parse object") {
         goblin::Object::Elf(elf) => {
             assert!(elf.entry == 0);


### PR DESCRIPTION
I think this closes #16. This commit makes `archive/mod.rs` no longer contain any `String`s.