### PR TITLE
Correct broken cpusubtype field in Header32

### DIFF
--- a/src/mach/header.rs
+++ b/src/mach/header.rs
@@ -165,11 +165,11 @@ pub struct Header32 {
     pub magic: u32,
     /// cpu specifier
     pub cputype: u32,
+    /// machine specifier
+    pub cpusubtype: u8,
     pub padding1: u8,
     pub padding2: u8,
     pub caps: u8,
-    /// machine specifier
-    pub cpusubtype: u8,
     /// type of file
     pub filetype: u32,
     /// number of load commands

--- a/src/mach/header.rs
+++ b/src/mach/header.rs
@@ -487,3 +487,16 @@ impl ctx::IntoCtx<container::Ctx> for Header {
         bytes.pwrite_with(self, 0, ctx).unwrap();
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_basic_header32() {
+        use super::Header;
+        use scroll::Pread;
+        let bytes = b"\xce\xfa\xed\xfe\x0c\x00\x00\x00\t\x00\x00\x00\n\x00\x00\x00\x06\x00\x00\x00\x8c\r\x00\x00\x00\x00\x00\x00\x1b\x00\x00\x00\x18\x00\x00\x00\xe0\xf7B\xbb\x1c\xf50w\xa6\xf7u\xa3\xba(";
+        let header: Header = bytes.pread(0).unwrap();
+        assert_eq!(header.cputype, 12);
+        assert_eq!(header.cpusubtype, 9);
+    }
+}

--- a/src/mach/header.rs
+++ b/src/mach/header.rs
@@ -492,11 +492,13 @@ impl ctx::IntoCtx<container::Ctx> for Header {
 mod tests {
     #[test]
     fn test_basic_header32() {
+        use mach::constants::cputype::CPU_TYPE_ARM;
+        const CPU_SUBTYPE_ARM_V7: u8 = 9;
         use super::Header;
         use scroll::Pread;
         let bytes = b"\xce\xfa\xed\xfe\x0c\x00\x00\x00\t\x00\x00\x00\n\x00\x00\x00\x06\x00\x00\x00\x8c\r\x00\x00\x00\x00\x00\x00\x1b\x00\x00\x00\x18\x00\x00\x00\xe0\xf7B\xbb\x1c\xf50w\xa6\xf7u\xa3\xba(";
         let header: Header = bytes.pread(0).unwrap();
-        assert_eq!(header.cputype, 12);
-        assert_eq!(header.cpusubtype, 9);
+        assert_eq!(header.cputype, CPU_TYPE_ARM);
+        assert_eq!(header.cpusubtype, CPU_SUBTYPE_ARM_V7);
     }
 }


### PR DESCRIPTION
Currently on 32bit headers the cpusubtype is read from the wrong byte which causes the value to effectively always be 0.

I am not entirely sure why this uses paddings in the header. If you look at the apple sources both cputype and cpusubtype are defined as i32 and the caps are fetched from the latter. I'm not sure if splitting it up into type + 2 byte padding + caps is correct here but I leave it unchanged because I do not understand the problem fully.