### PR TITLE
Work around truncated macho files

### DIFF
--- a/src/mach/segment.rs
+++ b/src/mach/segment.rs
@@ -235,7 +235,16 @@ impl<'a> Iterator for SectionIterator<'a> {
             self.idx += 1;
             match self.data.gread_with::<Section>(&mut self.offset, self.ctx) {
                 Ok(section) => {
-                    let data = &self.data[section.offset as usize..][..section.size as usize];
+                    // it's not uncommon to encounter macho files where files are
+                    // truncated but the sections are still remaining in the header.
+                    // Because of this we want to not panic here but instead just
+                    // slice down to a empty data slice.  This way only if code
+                    // actually needs to access those sections it will fall over.
+                    let data = self.data
+                        .get(section.offset as usize..)
+                        .unwrap_or(&[])
+                        .get(..section.size as usize)
+                        .unwrap_or(&[]);
                     Some(Ok((section, data)))
                 },
                 Err(e) => Some(Err(e.into()))

--- a/src/mach/segment.rs
+++ b/src/mach/segment.rs
@@ -242,9 +242,15 @@ impl<'a> Iterator for SectionIterator<'a> {
                     // actually needs to access those sections it will fall over.
                     let data = self.data
                         .get(section.offset as usize..)
-                        .unwrap_or(&[])
+                        .unwrap_or_else(|| {
+                            warn!("section #{} offset {} out of bounds", self.idx, section.offset);
+                            &[]
+                        })
                         .get(..section.size as usize)
-                        .unwrap_or(&[]);
+                        .unwrap_or_else(|| {
+                            warn!("section #{} size {} out of bounds", self.idx, section.size);
+                            &[]
+                        });
                     Some(Ok((section, data)))
                 },
                 Err(e) => Some(Err(e.into()))


### PR DESCRIPTION
This avoids panicking when iterating over sections if an improperly
truncated macho files is encountered.  This is happening for files
that are provided by customers we have no control over.  These files
currently read fine with macOS tools presumably because those sections
are not ever used (we only care about DWARF data).

I unfortunately cannot share those affected files for a testsuite as it's
coming from customer data.