### PR TITLE
Add support for cpu names

### DIFF
--- a/src/mach/constants.rs
+++ b/src/mach/constants.rs
@@ -194,6 +194,9 @@ pub mod cputype {
 
     pub type CpuType = u32;
 
+    /// the mask for CPU feature flags
+    pub const CPU_SUBTYPE_MASK: u32 = 0xff000000;
+
     pub const CPU_ARCH_MASK: CpuType = 0xff000000;
     pub const CPU_ARCH_ABI64: CpuType = 0x01000000;
     pub const CPU_TYPE_X86: CpuType = 7;

--- a/src/mach/constants.rs
+++ b/src/mach/constants.rs
@@ -192,26 +192,241 @@ pub const SEG_IMPORT: &'static str = "__IMPORT";
 
 pub mod cputype {
 
+    /// An alias for u32
     pub type CpuType = u32;
+    /// An alias for u32
+    pub type CpuSubType = u32;
 
     /// the mask for CPU feature flags
     pub const CPU_SUBTYPE_MASK: u32 = 0xff000000;
-
+    /// mask for architecture bits
     pub const CPU_ARCH_MASK: CpuType = 0xff000000;
+    /// the mask for 64 bit ABI
     pub const CPU_ARCH_ABI64: CpuType = 0x01000000;
-    pub const CPU_TYPE_X86: CpuType = 7;
-    pub const CPU_TYPE_ARM: CpuType = 12;
-    pub const CPU_TYPE_X86_64: CpuType = CPU_TYPE_X86 | CPU_ARCH_ABI64;
-    pub const CPU_TYPE_ARM64: CpuType = CPU_TYPE_ARM | CPU_ARCH_ABI64;
 
-    #[inline(always)]
-    pub fn cpu_type_to_str(cputype: CpuType) -> &'static str {
-        match cputype {
-            CPU_TYPE_ARM64 => "ARM64",
-            CPU_TYPE_X86_64 => "x86_64",
-            CPU_TYPE_ARM => "ARM",
-            CPU_TYPE_X86 => "x86",
-            _ => "UNIMPLEMENTED CPUTYPE",
+    // CPU Types
+    pub const CPU_TYPE_ANY: CpuType = !0;
+    pub const CPU_TYPE_VAX: CpuType = 1;
+    pub const CPU_TYPE_MC680X0: CpuType = 6;
+    pub const CPU_TYPE_X86: CpuType = 7;
+    pub const CPU_TYPE_I386: CpuType = CPU_TYPE_X86;
+    pub const CPU_TYPE_X86_64: CpuType = (CPU_TYPE_X86 | CPU_ARCH_ABI64);
+    pub const CPU_TYPE_MIPS: CpuType = 8;
+    pub const CPU_TYPE_MC98000: CpuType = 10;
+    pub const CPU_TYPE_HPPA: CpuType = 11;
+    pub const CPU_TYPE_ARM: CpuType = 12;
+    pub const CPU_TYPE_ARM64: CpuType = (CPU_TYPE_ARM | CPU_ARCH_ABI64);
+    pub const CPU_TYPE_MC88000: CpuType = 13;
+    pub const CPU_TYPE_SPARC: CpuType = 14;
+    pub const CPU_TYPE_I860: CpuType = 15;
+    pub const CPU_TYPE_ALPHA: CpuType = 16;
+    pub const CPU_TYPE_POWERPC: CpuType = 18;
+    pub const CPU_TYPE_POWERPC64: CpuType = (CPU_TYPE_POWERPC | CPU_ARCH_ABI64);
+
+    // CPU Subtypes
+    pub const CPU_SUBTYPE_MULTIPLE: CpuSubType = !0;
+    pub const CPU_SUBTYPE_LITTLE_ENDIAN: CpuSubType = 0;
+    pub const CPU_SUBTYPE_BIG_ENDIAN: CpuSubType = 1;
+    pub const CPU_SUBTYPE_VAX_ALL: CpuSubType = 0;
+    pub const CPU_SUBTYPE_VAX780: CpuSubType = 1;
+    pub const CPU_SUBTYPE_VAX785: CpuSubType = 2;
+    pub const CPU_SUBTYPE_VAX750: CpuSubType = 3;
+    pub const CPU_SUBTYPE_VAX730: CpuSubType = 4;
+    pub const CPU_SUBTYPE_UVAXI: CpuSubType = 5;
+    pub const CPU_SUBTYPE_UVAXII: CpuSubType = 6;
+    pub const CPU_SUBTYPE_VAX8200: CpuSubType = 7;
+    pub const CPU_SUBTYPE_VAX8500: CpuSubType = 8;
+    pub const CPU_SUBTYPE_VAX8600: CpuSubType = 9;
+    pub const CPU_SUBTYPE_VAX8650: CpuSubType = 10;
+    pub const CPU_SUBTYPE_VAX8800: CpuSubType = 11;
+    pub const CPU_SUBTYPE_UVAXIII: CpuSubType = 12;
+    pub const CPU_SUBTYPE_MC680X0_ALL: CpuSubType = 1;
+    pub const CPU_SUBTYPE_MC68030: CpuSubType = 1; /* compat */
+    pub const CPU_SUBTYPE_MC68040: CpuSubType = 2;
+    pub const CPU_SUBTYPE_MC68030_ONLY: CpuSubType = 3;
+
+    macro_rules! CPU_SUBTYPE_INTEL {
+        ($f:expr, $m:expr) => ({
+            ($f) + (($m) << 4)
+        })
+    }
+
+    pub const CPU_SUBTYPE_I386_ALL: CpuSubType = CPU_SUBTYPE_INTEL!(3, 0);
+    pub const CPU_SUBTYPE_386: CpuSubType = CPU_SUBTYPE_INTEL!(3, 0);
+    pub const CPU_SUBTYPE_486: CpuSubType = CPU_SUBTYPE_INTEL!(4, 0);
+    pub const CPU_SUBTYPE_486SX: CpuSubType = CPU_SUBTYPE_INTEL!(4, 8); // 8 << 4 = 128
+    pub const CPU_SUBTYPE_586: CpuSubType = CPU_SUBTYPE_INTEL!(5, 0);
+    pub const CPU_SUBTYPE_PENT: CpuSubType = CPU_SUBTYPE_INTEL!(5, 0);
+    pub const CPU_SUBTYPE_PENTPRO: CpuSubType = CPU_SUBTYPE_INTEL!(6, 1);
+    pub const CPU_SUBTYPE_PENTII_M3: CpuSubType = CPU_SUBTYPE_INTEL!(6, 3);
+    pub const CPU_SUBTYPE_PENTII_M5: CpuSubType = CPU_SUBTYPE_INTEL!(6, 5);
+    pub const CPU_SUBTYPE_CELERON: CpuSubType = CPU_SUBTYPE_INTEL!(7, 6);
+    pub const CPU_SUBTYPE_CELERON_MOBILE: CpuSubType = CPU_SUBTYPE_INTEL!(7, 7);
+    pub const CPU_SUBTYPE_PENTIUM_3: CpuSubType = CPU_SUBTYPE_INTEL!(8, 0);
+    pub const CPU_SUBTYPE_PENTIUM_3_M: CpuSubType = CPU_SUBTYPE_INTEL!(8, 1);
+    pub const CPU_SUBTYPE_PENTIUM_3_XEON: CpuSubType = CPU_SUBTYPE_INTEL!(8, 2);
+    pub const CPU_SUBTYPE_PENTIUM_M: CpuSubType = CPU_SUBTYPE_INTEL!(9, 0);
+    pub const CPU_SUBTYPE_PENTIUM_4: CpuSubType = CPU_SUBTYPE_INTEL!(10, 0);
+    pub const CPU_SUBTYPE_PENTIUM_4_M: CpuSubType = CPU_SUBTYPE_INTEL!(10, 1);
+    pub const CPU_SUBTYPE_ITANIUM: CpuSubType = CPU_SUBTYPE_INTEL!(11, 0);
+    pub const CPU_SUBTYPE_ITANIUM_2: CpuSubType = CPU_SUBTYPE_INTEL!(11, 1);
+    pub const CPU_SUBTYPE_XEON: CpuSubType = CPU_SUBTYPE_INTEL!(12, 0);
+    pub const CPU_SUBTYPE_XEON_MP: CpuSubType = CPU_SUBTYPE_INTEL!(12, 1);
+    pub const CPU_SUBTYPE_INTEL_FAMILY_MAX: CpuSubType = 15;
+    pub const CPU_SUBTYPE_INTEL_MODEL_ALL: CpuSubType = 0;
+    pub const CPU_SUBTYPE_X86_ALL: CpuSubType = 3;
+    pub const CPU_SUBTYPE_X86_64_ALL: CpuSubType = 3;
+    pub const CPU_SUBTYPE_X86_ARCH1: CpuSubType = 4;
+    pub const CPU_SUBTYPE_X86_64_H: CpuSubType = 8;
+    pub const CPU_SUBTYPE_MIPS_ALL: CpuSubType = 0;
+    pub const CPU_SUBTYPE_MIPS_R2300: CpuSubType = 1;
+    pub const CPU_SUBTYPE_MIPS_R2600: CpuSubType = 2;
+    pub const CPU_SUBTYPE_MIPS_R2800: CpuSubType = 3;
+    pub const CPU_SUBTYPE_MIPS_R2000A: CpuSubType = 4;
+    pub const CPU_SUBTYPE_MIPS_R2000: CpuSubType = 5;
+    pub const CPU_SUBTYPE_MIPS_R3000A: CpuSubType = 6;
+    pub const CPU_SUBTYPE_MIPS_R3000: CpuSubType = 7;
+    pub const CPU_SUBTYPE_MC98000_ALL: CpuSubType = 0;
+    pub const CPU_SUBTYPE_MC98601: CpuSubType = 1;
+    pub const CPU_SUBTYPE_HPPA_ALL: CpuSubType = 0;
+    pub const CPU_SUBTYPE_HPPA_7100: CpuSubType = 0;
+    pub const CPU_SUBTYPE_HPPA_7100LC: CpuSubType = 1;
+    pub const CPU_SUBTYPE_MC88000_ALL: CpuSubType = 0;
+    pub const CPU_SUBTYPE_MC88100: CpuSubType = 1;
+    pub const CPU_SUBTYPE_MC88110: CpuSubType = 2;
+    pub const CPU_SUBTYPE_SPARC_ALL: CpuSubType = 0;
+    pub const CPU_SUBTYPE_I860_ALL: CpuSubType = 0;
+    pub const CPU_SUBTYPE_I860_860: CpuSubType = 1;
+    pub const CPU_SUBTYPE_POWERPC_ALL: CpuSubType = 0;
+    pub const CPU_SUBTYPE_POWERPC_601: CpuSubType = 1;
+    pub const CPU_SUBTYPE_POWERPC_602: CpuSubType = 2;
+    pub const CPU_SUBTYPE_POWERPC_603: CpuSubType = 3;
+    pub const CPU_SUBTYPE_POWERPC_603E: CpuSubType = 4;
+    pub const CPU_SUBTYPE_POWERPC_603EV: CpuSubType = 5;
+    pub const CPU_SUBTYPE_POWERPC_604: CpuSubType = 6;
+    pub const CPU_SUBTYPE_POWERPC_604E: CpuSubType = 7;
+    pub const CPU_SUBTYPE_POWERPC_620: CpuSubType = 8;
+    pub const CPU_SUBTYPE_POWERPC_750: CpuSubType = 9;
+    pub const CPU_SUBTYPE_POWERPC_7400: CpuSubType = 10;
+    pub const CPU_SUBTYPE_POWERPC_7450: CpuSubType = 11;
+    pub const CPU_SUBTYPE_POWERPC_970: CpuSubType = 100;
+    pub const CPU_SUBTYPE_ARM_ALL: CpuSubType = 0;
+    pub const CPU_SUBTYPE_ARM_V4T: CpuSubType = 5;
+    pub const CPU_SUBTYPE_ARM_V6: CpuSubType = 6;
+    pub const CPU_SUBTYPE_ARM_V5TEJ: CpuSubType = 7;
+    pub const CPU_SUBTYPE_ARM_XSCALE: CpuSubType = 8;
+    pub const CPU_SUBTYPE_ARM_V7: CpuSubType = 9;
+    pub const CPU_SUBTYPE_ARM_V7F: CpuSubType = 10;
+    pub const CPU_SUBTYPE_ARM_V7S: CpuSubType = 11;
+    pub const CPU_SUBTYPE_ARM_V7K: CpuSubType = 12;
+    pub const CPU_SUBTYPE_ARM_V6M: CpuSubType = 14;
+    pub const CPU_SUBTYPE_ARM_V7M: CpuSubType = 15;
+    pub const CPU_SUBTYPE_ARM_V7EM: CpuSubType = 16;
+    pub const CPU_SUBTYPE_ARM_V8: CpuSubType = 13;
+    pub const CPU_SUBTYPE_ARM64_ALL: CpuSubType = 0;
+    pub const CPU_SUBTYPE_ARM64_V8: CpuSubType = 1;
+
+    macro_rules! cpu_flag_mapping {
+        (
+            $(($name:expr, $cputype:ident, $cpusubtype:ident),)*
+        ) => {
+            fn get_arch_from_flag_no_alias(name: &str) -> Option<(CpuType, CpuSubType)> {
+                match name {
+                    $($name => Some(($cputype, $cpusubtype)),)*
+                    _ => None
+                }
+            }
+
+            /// Get the architecture name from cputype and cpusubtype
+            pub fn get_arch_name_from_types(cputype: CpuType, cpusubtype: CpuSubType)
+                -> Option<&'static str> {
+                match (cputype, cpusubtype) {
+                    $(($cputype, $cpusubtype) => Some($name),)*
+                    (_, _) => None
+                }
+            }
         }
+    }
+
+    /// Get the cputype and cpusubtype from a name
+    pub fn get_arch_from_flag(name: &str) -> Option<(CpuType, CpuSubType)> {
+        get_arch_from_flag_no_alias(name).or_else(|| {
+            // we also handle some common aliases
+            match name {
+                // these are used by apple
+                "pentium" => Some((CPU_TYPE_I386, CPU_SUBTYPE_PENT)),
+                "pentpro" => Some((CPU_TYPE_I386, CPU_SUBTYPE_PENTPRO)),
+                // these are used commonly for consistency
+                "x86" => Some((CPU_TYPE_I386, CPU_SUBTYPE_I386_ALL)),
+                _ => None,
+            }
+        })
+    }
+
+    cpu_flag_mapping! {
+        // generic types
+        ("any", CPU_TYPE_ANY, CPU_SUBTYPE_MULTIPLE),
+        ("little", CPU_TYPE_ANY, CPU_SUBTYPE_LITTLE_ENDIAN),
+        ("big", CPU_TYPE_ANY, CPU_SUBTYPE_BIG_ENDIAN),
+
+        // macho names
+        ("ppc64", CPU_TYPE_POWERPC64, CPU_SUBTYPE_POWERPC_ALL),
+        ("x86_64", CPU_TYPE_X86_64, CPU_SUBTYPE_X86_64_ALL),
+        ("x86_64h", CPU_TYPE_X86_64, CPU_SUBTYPE_X86_64_H),
+        ("arm64", CPU_TYPE_ARM64, CPU_SUBTYPE_ARM64_ALL),
+        ("ppc970-64", CPU_TYPE_POWERPC64, CPU_SUBTYPE_POWERPC_970),
+        ("ppc", CPU_TYPE_POWERPC, CPU_SUBTYPE_POWERPC_ALL),
+        ("i386", CPU_TYPE_I386, CPU_SUBTYPE_I386_ALL),
+        ("m68k", CPU_TYPE_MC680X0, CPU_SUBTYPE_MC680X0_ALL),
+        ("hppa", CPU_TYPE_HPPA, CPU_SUBTYPE_HPPA_ALL),
+        ("sparc", CPU_TYPE_SPARC, CPU_SUBTYPE_SPARC_ALL),
+        ("m88k", CPU_TYPE_MC88000, CPU_SUBTYPE_MC88000_ALL),
+        ("i860", CPU_TYPE_I860, CPU_SUBTYPE_I860_ALL),
+        ("arm", CPU_TYPE_ARM, CPU_SUBTYPE_ARM_ALL),
+        ("ppc601", CPU_TYPE_POWERPC, CPU_SUBTYPE_POWERPC_601),
+        ("ppc603", CPU_TYPE_POWERPC, CPU_SUBTYPE_POWERPC_603),
+        ("ppc603e", CPU_TYPE_POWERPC, CPU_SUBTYPE_POWERPC_603E),
+        ("ppc603ev", CPU_TYPE_POWERPC,CPU_SUBTYPE_POWERPC_603EV),
+        ("ppc604", CPU_TYPE_POWERPC, CPU_SUBTYPE_POWERPC_604),
+        ("ppc604e",CPU_TYPE_POWERPC, CPU_SUBTYPE_POWERPC_604E),
+        ("ppc750", CPU_TYPE_POWERPC, CPU_SUBTYPE_POWERPC_750),
+        ("ppc7400", CPU_TYPE_POWERPC, CPU_SUBTYPE_POWERPC_7400),
+        ("ppc7450", CPU_TYPE_POWERPC, CPU_SUBTYPE_POWERPC_7450),
+        ("ppc970", CPU_TYPE_POWERPC, CPU_SUBTYPE_POWERPC_970),
+        ("i486", CPU_TYPE_I386, CPU_SUBTYPE_486),
+        ("i486SX", CPU_TYPE_I386, CPU_SUBTYPE_486SX),
+        ("i586", CPU_TYPE_I386, CPU_SUBTYPE_586),
+        ("i686", CPU_TYPE_I386, CPU_SUBTYPE_PENTPRO),
+        ("pentIIm3", CPU_TYPE_I386, CPU_SUBTYPE_PENTII_M3),
+        ("pentIIm5", CPU_TYPE_I386, CPU_SUBTYPE_PENTII_M5),
+        ("pentium4", CPU_TYPE_I386, CPU_SUBTYPE_PENTIUM_4),
+        ("m68030", CPU_TYPE_MC680X0, CPU_SUBTYPE_MC68030_ONLY),
+        ("m68040", CPU_TYPE_MC680X0, CPU_SUBTYPE_MC68040),
+        ("hppa7100LC", CPU_TYPE_HPPA,  CPU_SUBTYPE_HPPA_7100LC),
+        ("armv4t", CPU_TYPE_ARM, CPU_SUBTYPE_ARM_V4T),
+        ("armv5", CPU_TYPE_ARM, CPU_SUBTYPE_ARM_V5TEJ),
+        ("xscale", CPU_TYPE_ARM, CPU_SUBTYPE_ARM_XSCALE),
+        ("armv6", CPU_TYPE_ARM, CPU_SUBTYPE_ARM_V6),
+        ("armv6m", CPU_TYPE_ARM, CPU_SUBTYPE_ARM_V6M),
+        ("armv7", CPU_TYPE_ARM, CPU_SUBTYPE_ARM_V7),
+        ("armv7f", CPU_TYPE_ARM, CPU_SUBTYPE_ARM_V7F),
+        ("armv7s", CPU_TYPE_ARM, CPU_SUBTYPE_ARM_V7S),
+        ("armv7k", CPU_TYPE_ARM, CPU_SUBTYPE_ARM_V7K),
+        ("armv7m", CPU_TYPE_ARM, CPU_SUBTYPE_ARM_V7M),
+        ("armv7em", CPU_TYPE_ARM, CPU_SUBTYPE_ARM_V7EM),
+        ("arm64v8", CPU_TYPE_ARM64, CPU_SUBTYPE_ARM64_V8),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_basic_mapping() {
+        use super::cputype::*;
+
+        assert_eq!(get_arch_from_flag("armv7"), Some((CPU_TYPE_ARM, CPU_SUBTYPE_ARM_V7)));
+        assert_eq!(get_arch_name_from_types(CPU_TYPE_ARM, CPU_SUBTYPE_ARM_V7), Some("armv7"));
+        assert_eq!(get_arch_from_flag("i386"), Some((CPU_TYPE_I386, CPU_SUBTYPE_I386_ALL)));
+        assert_eq!(get_arch_from_flag("x86"), Some((CPU_TYPE_I386, CPU_SUBTYPE_I386_ALL)));
     }
 }

--- a/src/mach/fat.rs
+++ b/src/mach/fat.rs
@@ -6,7 +6,7 @@ use std::fs::File;
 use std::io::{self, Read};
 
 use scroll::{self, Pread};
-use mach::constants::cputype;
+use mach::constants::cputype::{CpuType, CpuSubType, CPU_SUBTYPE_MASK, CPU_ARCH_ABI64};
 use error;
 
 pub const FAT_MAGIC: u32 = 0xcafebabe;
@@ -77,8 +77,8 @@ pub const SIZEOF_FAT_ARCH: usize = 20;
 impl fmt::Debug for FatArch {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.debug_struct("FatArch")
-            .field("cputype", &cputype::cpu_type_to_str(self.cputype))
-            .field("cmdsize", &self.cpusubtype)
+            .field("cputype", &self.cputype())
+            .field("cmdsize", &self.cpusubtype())
             .field("offset",  &format_args!("{:#x}", &self.offset))
             .field("size",    &self.size)
             .field("align",   &self.align)
@@ -94,10 +94,26 @@ impl FatArch {
         &bytes[start..end]
     }
 
+    /// Returns the cpu type
+    pub fn cputype(&self) -> CpuType {
+        self.cputype
+    }
+
+    /// Returns the cpu subtype with the capabilities removed
+    pub fn cpusubtype(&self) -> CpuSubType {
+        self.cpusubtype & !CPU_SUBTYPE_MASK
+    }
+
+    /// Returns the capabilities of the CPU
+    pub fn cpu_caps(&self) -> u32 {
+        (self.cpusubtype & CPU_SUBTYPE_MASK) >> 24
+    }
+
     /// Whether this fat architecture header describes a 64-bit binary
     pub fn is_64(&self) -> bool {
-        self.cputype == cputype::CPU_TYPE_X86_64 || self.cputype == cputype::CPU_TYPE_ARM64
+        (self.cputype & CPU_ARCH_ABI64) != 0
     }
+
     /// Parse a `FatArch` header from `bytes` at `offset`
     pub fn parse(bytes: &[u8], offset: usize) -> error::Result<Self> {
         let arch = bytes.pread_with::<FatArch>(offset, scroll::BE)?;

--- a/src/mach/fat.rs
+++ b/src/mach/fat.rs
@@ -111,7 +111,7 @@ impl FatArch {
 
     /// Whether this fat architecture header describes a 64-bit binary
     pub fn is_64(&self) -> bool {
-        (self.cputype & CPU_ARCH_ABI64) != 0
+        (self.cputype & CPU_ARCH_ABI64) == CPU_ARCH_ABI64
     }
 
     /// Parse a `FatArch` header from `bytes` at `offset`

--- a/src/mach/header.rs
+++ b/src/mach/header.rs
@@ -5,7 +5,7 @@ use scroll::{self, ctx, Pwrite, Endian};
 use scroll::ctx::SizeWith;
 use plain::{self, Plain};
 
-use mach::constants::cputype::{cpu_type_to_str, CPU_SUBTYPE_MASK};
+use mach::constants::cputype::{CpuType, CpuSubType, CPU_SUBTYPE_MASK};
 use error;
 use container::{self, Container};
 
@@ -157,7 +157,7 @@ pub fn filetype_to_str(filetype: u32) -> &'static str {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, Debug)]
 #[derive(Pread, Pwrite, SizeWith)]
 /// A 32-bit Mach-o header
 pub struct Header32 {
@@ -181,21 +181,6 @@ pub const SIZEOF_HEADER_32: usize = 0x1c;
 
 unsafe impl Plain for Header32 {}
 
-impl fmt::Debug for Header32 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f,
-               "0x{:x} {} 0x{:x} {} {} {} 0x{:x}",
-               self.magic,
-               cpu_type_to_str(self.cputype),
-               self.cpusubtype,
-               filetype_to_str(self.filetype),
-               self.ncmds,
-               self.sizeofcmds,
-               self.flags,
-        )
-    }
-}
-
 impl Header32 {
     /// Transmutes the given byte array into the corresponding 32-bit Mach-o header
     pub fn from_bytes(bytes: &[u8; SIZEOF_HEADER_32]) -> &Self {
@@ -207,7 +192,7 @@ impl Header32 {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, Debug)]
 #[derive(Pread, Pwrite, SizeWith)]
 /// A 64-bit Mach-o header
 pub struct Header64 {
@@ -231,21 +216,6 @@ pub struct Header64 {
 unsafe impl Plain for Header64 {}
 
 pub const SIZEOF_HEADER_64: usize = 32;
-
-impl fmt::Debug for Header64 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f,
-               "0x{:x} {} 0x{:x} {} {} {} 0x{:x} 0x{:x}",
-               self.magic,
-               cpu_type_to_str(self.cputype),
-               self.cpusubtype,
-               filetype_to_str(self.filetype),
-               self.ncmds,
-               self.sizeofcmds,
-               self.flags,
-               self.reserved)
-    }
-}
 
 impl Header64 {
     /// Transmutes the given byte array into the corresponding 64-bit Mach-o header
@@ -280,8 +250,8 @@ impl fmt::Debug for Header {
         write!(f,
                "0x{:x} {} 0x{:x} {} {} {} 0x{:x} 0x{:x}",
                self.magic,
-               cpu_type_to_str(self.cputype),
-               self.cpusubtype,
+               self.cputype(),
+               self.cpusubtype(),
                filetype_to_str(self.filetype),
                self.ncmds,
                self.sizeofcmds,
@@ -372,11 +342,11 @@ impl Header {
         Self::size_with(&self.container())
     }
     /// Returns the cpu type
-    pub fn cputype(&self) -> u32 {
+    pub fn cputype(&self) -> CpuType {
         self.cputype
     }
     /// Returns the cpu subtype with the capabilities removed
-    pub fn cpusubtype(&self) -> u32 {
+    pub fn cpusubtype(&self) -> CpuSubType {
         self.cpusubtype & !CPU_SUBTYPE_MASK
     }
     /// Returns the capabilities of the CPU

--- a/src/mach/header.rs
+++ b/src/mach/header.rs
@@ -5,7 +5,7 @@ use scroll::{self, ctx, Pwrite, Endian};
 use scroll::ctx::SizeWith;
 use plain::{self, Plain};
 
-use mach::constants::cputype::cpu_type_to_str;
+use mach::constants::cputype::{cpu_type_to_str, CPU_SUBTYPE_MASK};
 use error;
 use container::{self, Container};
 
@@ -370,6 +370,18 @@ impl Header {
     pub fn size(&self) -> usize {
         use scroll::ctx::SizeWith;
         Self::size_with(&self.container())
+    }
+    /// Returns the cpu type
+    pub fn cputype(&self) -> u32 {
+        self.cputype
+    }
+    /// Returns the cpu subtype with the capabilities removed
+    pub fn cpusubtype(&self) -> u32 {
+        self.cpusubtype & !CPU_SUBTYPE_MASK
+    }
+    /// Returns the capabilities of the CPU
+    pub fn cpu_caps(&self) -> u32 {
+        (self.cpusubtype & CPU_SUBTYPE_MASK) >> 24
     }
     pub fn ctx(&self) -> error::Result<container::Ctx> {
         // todo check magic is not junk, and error otherwise


### PR DESCRIPTION
This adds the mapping of cpu names (flags) to the types that is also used
by apple and others. It's the mapping we (@getsentry) use and this is also
used by rust-macho. One modification I made to the table is register x86
as alias for i386 which we encounter in some cases.

It also changes the debug output to no longer show the cpu names but instead
the code which is easier to work with and consistent with other tools.