### PR TITLE
Remove the use of `goblin::parse` in `lib.rs` example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@
 //!             let mut fd = File::open(path)?;
 //!             let mut buffer = Vec::new();
 //!             fd.read_to_end(&mut buffer)?;
-//!             match goblin::parse(&buffer)? {
+//!             match Object::parse(&buffer)? {
 //!                 Object::Elf(elf) => {
 //!                     println!("elf: {:#?}", &elf);
 //!                 },


### PR DESCRIPTION
I think you forgot this one. :)