### PR TITLE
Bump version of the `plain` dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ include = ["src/**/*", "Cargo.toml", "CHANGELOG.md", "LICENSE", "README.md", "et
 env_logger = "0.4.3"
 
 [dependencies]
-plain = "0.2.1"
+plain = "0.2.3"
 log = { version = "0.3.8", optional = true }
 
 [dependencies.scroll]


### PR DESCRIPTION
As embarassing as it is to admit, there was a potential integer overflow in `plain`. I don't know for certain that goblin is affected, but you should probably rebuild the package just to be sure.