### PR TITLE
Add alloc feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ default_features = false
 default = ["std", "elf32", "elf64", "mach32", "mach64", "pe32", "pe64", "archive", "endian_fd"]
 std = ["alloc", "scroll/std"]
 alloc = ["scroll/derive", "log"]
-endian_fd = ["alloc", "elf32", "elf64", "mach32", "mach64", "pe32", "pe64", "archive"]
+endian_fd = ["alloc"]
 elf32 = []
 elf64 = []
 # for now we will require mach and pe to be alloc + endian_fd

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,25 +18,29 @@ env_logger = "0.4.3"
 
 [dependencies]
 plain = "0.2.3"
-log = { version = "0.3.8", optional = true }
+
+[dependencies.log]
+version = "0.3.8"
+default-features = false
+optional = true
 
 [dependencies.scroll]
-version = "0.8.0"
+version = "0.9.0"
 default_features = false
 
 [features]
-default = ["std", "elf32", "elf64", "mach32", "mach64", "pe32", "pe64", "goblin", "endian_fd", "archive", "scroll/std"]
-std = ["scroll/derive", "log"]
-endian_fd = ["std"]
+default = ["std", "elf32", "elf64", "mach32", "mach64", "pe32", "pe64", "archive", "endian_fd"]
+std = ["alloc", "scroll/std"]
+alloc = ["scroll/derive", "log"]
+endian_fd = ["alloc", "elf32", "elf64", "mach32", "mach64", "pe32", "pe64", "archive"]
 elf32 = []
 elf64 = []
-# for now we will require mach and pe to be std + endian_fd
-mach32 = ["std", "endian_fd"]
-mach64 = ["std", "endian_fd"]
-pe32 = ["std", "endian_fd"]
-pe64 = ["std", "endian_fd"]
-archive = ["endian_fd"]
-goblin = []
+# for now we will require mach and pe to be alloc + endian_fd
+mach32 = ["alloc", "endian_fd"]
+mach64 = ["alloc", "endian_fd"]
+pe32 = ["alloc", "endian_fd"]
+pe64 = ["alloc", "endian_fd"]
+archive = ["alloc"]
 
 # [profile.dev]
 # opt-level = 0

--- a/Makefile
+++ b/Makefile
@@ -25,24 +25,28 @@ example:
 api:
 	cargo build --no-default-features
 	cargo build --no-default-features --features="std"
+	cargo build --no-default-features --features="endian_fd std"
 	cargo build --no-default-features --features="elf32"
 	cargo build --no-default-features --features="elf32 elf64"
 	cargo build --no-default-features --features="elf32 elf64 std"
+	cargo build --no-default-features --features="elf32 elf64 endian_fd std"
 	cargo build --no-default-features --features="archive std"
+	cargo build --no-default-features --features="mach64 std"
+	cargo build --no-default-features --features="mach32 std"
 	cargo build --no-default-features --features="mach64 mach32 std"
+	cargo build --no-default-features --features="pe32 std"
 	cargo build --no-default-features --features="pe32 pe64 std"
-	cargo build --no-default-features --features="endian_fd std"
 	cargo build
 
 nightly_api:
 	cargo build --no-default-features --features="alloc"
-	cargo build --no-default-features --features="elf32 elf64 alloc"
+	cargo build --no-default-features --features="endian_fd"
+	cargo build --no-default-features --features="elf32 elf64 endian_fd"
 	cargo build --no-default-features --features="archive"
 	cargo build --no-default-features --features="mach64"
 	cargo build --no-default-features --features="mach32"
 	cargo build --no-default-features --features="mach64 mach32"
 	cargo build --no-default-features --features="pe32"
 	cargo build --no-default-features --features="pe32 pe64"
-	cargo build --no-default-features --features="endian_fd"
 
 .PHONY: clean test example doc

--- a/Makefile
+++ b/Makefile
@@ -28,13 +28,21 @@ api:
 	cargo build --no-default-features --features="elf32"
 	cargo build --no-default-features --features="elf32 elf64"
 	cargo build --no-default-features --features="elf32 elf64 std"
-	cargo build --no-default-features --features="elf32 elf64 endian_fd"
+	cargo build --no-default-features --features="archive std"
+	cargo build --no-default-features --features="mach64 mach32 std"
+	cargo build --no-default-features --features="pe32 pe64 std"
+	cargo build --no-default-features --features="endian_fd std"
+	cargo build
+
+nightly_api:
+	cargo build --no-default-features --features="alloc"
+	cargo build --no-default-features --features="elf32 elf64 alloc"
 	cargo build --no-default-features --features="archive"
 	cargo build --no-default-features --features="mach64"
 	cargo build --no-default-features --features="mach32"
 	cargo build --no-default-features --features="mach64 mach32"
 	cargo build --no-default-features --features="pe32"
 	cargo build --no-default-features --features="pe32 pe64"
-	cargo build
+	cargo build --no-default-features --features="endian_fd"
 
 .PHONY: clean test example doc

--- a/src/archive/mod.rs
+++ b/src/archive/mod.rs
@@ -11,8 +11,9 @@ use scroll::{self, Pread};
 use strtab;
 use error::{Result, Error};
 
-use std::usize;
-use std::collections::HashMap;
+use core::usize;
+use alloc::btree_map::BTreeMap;
+use alloc::vec::Vec;
 
 pub const SIZEOF_MAGIC: usize = 8;
 /// The magic number of a Unix Archive
@@ -334,9 +335,9 @@ pub struct Archive<'a> {
     sysv_name_index: NameIndex<'a>,
     // the array of members, which are indexed by the members hash and symbol index
     member_array: Vec<Member<'a>>,
-    members: HashMap<&'a str, usize>,
+    members: BTreeMap<&'a str, usize>,
     // symbol -> member
-    symbol_index: HashMap<&'a str, usize>
+    symbol_index: BTreeMap<&'a str, usize>
 }
 
 
@@ -383,8 +384,8 @@ impl<'a> Archive<'a> {
         }
 
         // preprocess member names
-        let mut members = HashMap::new();
-        let mut member_index_by_offset: HashMap<u32, usize> = HashMap::with_capacity(member_array.len());
+        let mut members = BTreeMap::new();
+        let mut member_index_by_offset: BTreeMap<u32, usize> = BTreeMap::new();
         for (i, member) in member_array.iter_mut().enumerate() {
             // copy in any SysV extended names
             if let Ok(sysv_name) = sysv_name_index.get(member.raw_name()) {
@@ -400,7 +401,7 @@ impl<'a> Archive<'a> {
         }
 
         // build the symbol index, translating symbol names into member indexes
-        let mut symbol_index: HashMap<&str, usize> = HashMap::new();
+        let mut symbol_index: BTreeMap<&str, usize> = BTreeMap::new();
         for (member_offset, name) in index.symbol_indexes.iter().zip(index.strtab.iter()) {
             let name = name.clone();
             let member_index = member_index_by_offset[member_offset];

--- a/src/elf/mod.rs
+++ b/src/elf/mod.rs
@@ -53,18 +53,12 @@ pub mod reloc;
 pub mod note;
 
 
-macro_rules! if_sylvan {
-    ($($i:item)*) => ($(
-        #[cfg(all(feature = "std", feature = "elf32", feature = "elf64", feature = "endian_fd"))]
-        $i
-    )*)
-}
-
-if_sylvan! {
+if_endian_fd! {
     use scroll::{self, ctx, Pread, Endian};
     use strtab::Strtab;
     use error;
     use container::{Container, Ctx};
+    use alloc::vec::Vec;
 
     pub type Header = header::Header;
     pub type ProgramHeader = program_header::ProgramHeader;

--- a/src/elf/mod.rs
+++ b/src/elf/mod.rs
@@ -52,8 +52,14 @@ pub mod dyn;
 pub mod reloc;
 pub mod note;
 
+macro_rules! if_sylvan {
+    ($($i:item)*) => ($(
+        #[cfg(all(feature = "elf32", feature = "elf64", feature = "endian_fd"))]
+        $i
+    )*)
+}
 
-if_endian_fd! {
+if_sylvan! {
     use scroll::{self, ctx, Pread, Endian};
     use strtab::Strtab;
     use error;

--- a/src/elf/note.rs
+++ b/src/elf/note.rs
@@ -32,7 +32,7 @@ pub const NT_GNU_BUILD_ID: u32 = 3;
 pub const NT_GNU_GOLD_VERSION: u32 = 4;
 
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "std", derive(Pread, Pwrite, IOread, IOwrite, SizeWith))]
+#[cfg_attr(feature = "alloc", derive(Pread, Pwrite, IOread, IOwrite, SizeWith))]
 #[repr(C)]
 /// Note section contents. Each entry in the note section begins with a header of a fixed form.
 pub struct Nhdr32 {
@@ -45,7 +45,7 @@ pub struct Nhdr32 {
 }
 
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "std", derive(Pread, Pwrite, IOread, IOwrite, SizeWith))]
+#[cfg_attr(feature = "alloc", derive(Pread, Pwrite, IOread, IOwrite, SizeWith))]
 #[repr(C)]
 /// Note section contents. Each entry in the note section begins with a header of a fixed form.
 pub struct Nhdr64 {
@@ -57,10 +57,11 @@ pub struct Nhdr64 {
     pub n_type: u64,
 }
 
-if_std! {
+if_alloc! {
     use error;
     use container;
     use scroll::{ctx, Pread};
+    use alloc::vec::Vec;
 
     /// An iterator over ELF binary notes in a note section or segment
     pub struct NoteDataIterator<'a> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,8 +4,9 @@
 use scroll;
 use core::result;
 use core::fmt::{self, Display};
-use std::error;
-use std::io;
+use alloc::string::String;
+#[cfg(feature = "std")]
+use std::{error, io};
 
 #[derive(Debug)]
 /// A custom Goblin error
@@ -17,17 +18,26 @@ pub enum Error {
     /// An error emanating from reading and interpreting bytes
     Scroll(scroll::Error),
     /// An IO based error
+    #[cfg(feature = "std")]
     IO(io::Error),
 }
 
-impl error::Error for Error {
-    fn description(&self) -> &str {
+impl Error {
+    pub fn description(&self) -> &str {
         match *self {
+            #[cfg(feature = "std")]
             Error::IO(_) => { "IO error" }
             Error::Scroll(_) => { "Scroll error" }
             Error::BadMagic(_) => { "Invalid magic number" }
             Error::Malformed(_) => { "Entity is malformed in some way" }
         }
+    }
+}
+
+#[cfg(feature = "std")]
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        Error::description(self)
     }
     fn cause(&self) -> Option<&error::Error> {
         match *self {
@@ -39,6 +49,7 @@ impl error::Error for Error {
     }
 }
 
+#[cfg(feature = "std")]
 impl From<io::Error> for Error {
     fn from(err: io::Error) -> Error {
         Error::IO(err)
@@ -54,6 +65,7 @@ impl From<scroll::Error> for Error {
 impl Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {
+            #[cfg(feature = "std")]
             Error::IO(ref err) => { write!(fmt, "{}", err) },
             Error::Scroll(ref err) => { write!(fmt, "{}", err) },
             Error::BadMagic(magic) => { write! (fmt, "Invalid magic number: 0x{:x}", magic) },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,32 +79,64 @@
 //! via `endian_fd`
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(all(feature = "alloc", not(feature = "std")), feature(alloc))]
 
 extern crate plain;
-#[cfg_attr(feature = "std", macro_use)]
+#[cfg_attr(feature = "alloc", macro_use)]
 extern crate scroll;
 
-#[cfg_attr(feature = "std", macro_use)]
-#[cfg(feature = "std")] extern crate log;
+#[cfg(feature = "log")]
+#[macro_use]
+extern crate log;
 
 #[cfg(feature = "std")]
 extern crate core;
 
-#[cfg(feature = "std")]
-pub mod error;
+#[cfg(all(feature = "alloc", not(feature = "std")))]
+#[macro_use]
+extern crate alloc;
 
-pub mod strtab;
+#[cfg(feature = "std")]
+mod alloc {
+    pub use std::borrow;
+    pub use std::boxed;
+    pub use std::string;
+    pub use std::vec;
+    pub use std::collections::btree_map;
+}
 
 /////////////////////////
 // Misc/Helper Modules
 /////////////////////////
 
+#[allow(unused)]
 macro_rules! if_std {
     ($($i:item)*) => ($(
         #[cfg(feature = "std")]
         $i
     )*)
 }
+
+#[allow(unused)]
+macro_rules! if_alloc {
+    ($($i:item)*) => ($(
+        #[cfg(feature = "alloc")]
+        $i
+    )*)
+}
+
+#[allow(unused)]
+macro_rules! if_endian_fd {
+    ($($i:item)*) => ($(
+        #[cfg(feature = "endian_fd")]
+        $i
+    )*)
+}
+
+#[cfg(feature = "alloc")]
+pub mod error;
+
+pub mod strtab;
 
 /// Binary container size information and byte-order context
 pub mod container {
@@ -190,7 +222,7 @@ pub mod container {
     }
 }
 
-if_std! {
+if_endian_fd! {
 
     #[derive(Debug, Default)]
     /// Information obtained from a peek `Hint`
@@ -211,7 +243,6 @@ if_std! {
     }
 
     /// Peeks at `bytes`, and returns a `Hint`
-    #[cfg(all(feature = "endian_fd", feature = "elf64", feature = "elf32", feature = "pe64", feature = "pe32", feature = "mach64", feature = "mach32", feature = "archive"))]
     pub fn peek_bytes(bytes: &[u8; 16]) -> error::Result<Hint> {
         use scroll::{Pread, LE, BE};
         use mach::{fat, header};
@@ -252,7 +283,7 @@ if_std! {
     }
 
     /// Peeks at the underlying Read object. Requires the underlying bytes to have at least 16 byte length. Resets the seek to `Start` after reading.
-    #[cfg(all(feature = "endian_fd", feature = "elf64", feature = "elf32", feature = "pe64", feature = "pe32", feature = "mach64", feature = "mach32", feature = "archive"))]
+    #[cfg(feature = "std")]
     pub fn peek<R: ::std::io::Read + ::std::io::Seek>(fd: &mut R) -> error::Result<Hint> {
         use std::io::SeekFrom;
         let mut bytes = [0u8; 16];
@@ -261,38 +292,38 @@ if_std! {
         fd.seek(SeekFrom::Start(0))?;
         peek_bytes(&bytes)
     }
-}
 
-#[cfg(all(feature = "endian_fd", feature = "elf64", feature = "elf32", feature = "pe64", feature = "pe32", feature = "mach64", feature = "mach32", feature = "archive"))]
-#[derive(Debug)]
-/// A parseable object that goblin understands
-pub enum Object<'a> {
-    /// An ELF32/ELF64!
-    Elf(elf::Elf<'a>),
-    /// A PE32/PE32+!
-    PE(pe::PE<'a>),
-    /// A 32/64-bit Mach-o binary _OR_ it is a multi-architecture binary container!
-    Mach(mach::Mach<'a>),
-    /// A Unix archive
-    Archive(archive::Archive<'a>),
-    /// None of the above, with the given magic value
-    Unknown(u64),
-}
+    #[derive(Debug)]
+    /// A parseable object that goblin understands
+    pub enum Object<'a> {
+        /// An ELF32/ELF64!
+        Elf(elf::Elf<'a>),
+        /// A PE32/PE32+!
+        PE(pe::PE<'a>),
+        /// A 32/64-bit Mach-o binary _OR_ it is a multi-architecture binary container!
+        Mach(mach::Mach<'a>),
+        /// A Unix archive
+        Archive(archive::Archive<'a>),
+        /// None of the above, with the given magic value
+        Unknown(u64),
+    }
 
-#[cfg(all(feature = "endian_fd", feature = "elf64", feature = "elf32", feature = "pe64", feature = "pe32", feature = "mach64", feature = "mach32", feature = "archive"))]
-impl<'a> Object<'a> {
-    /// Tries to parse an `Object` from `bytes`
-    pub fn parse(bytes: &[u8]) -> error::Result<Object> {
-        use std::io::Cursor;
-        match peek(&mut Cursor::new(&bytes))? {
-            Hint::Elf(_) => Ok(Object::Elf(elf::Elf::parse(bytes)?)),
-            Hint::Mach(_) | Hint::MachFat(_) => Ok(Object::Mach(mach::Mach::parse(bytes)?)),
-            Hint::Archive => Ok(Object::Archive(archive::Archive::parse(bytes)?)),
-            Hint::PE => Ok(Object::PE(pe::PE::parse(bytes)?)),
-            Hint::Unknown(magic) => Ok(Object::Unknown(magic))
+    // TODO: this could avoid std using peek_bytes
+    #[cfg(feature = "std")]
+    impl<'a> Object<'a> {
+        /// Tries to parse an `Object` from `bytes`
+        pub fn parse(bytes: &[u8]) -> error::Result<Object> {
+            use std::io::Cursor;
+            match peek(&mut Cursor::new(&bytes))? {
+                Hint::Elf(_) => Ok(Object::Elf(elf::Elf::parse(bytes)?)),
+                Hint::Mach(_) | Hint::MachFat(_) => Ok(Object::Mach(mach::Mach::parse(bytes)?)),
+                Hint::Archive => Ok(Object::Archive(archive::Archive::parse(bytes)?)),
+                Hint::PE => Ok(Object::PE(pe::PE::parse(bytes)?)),
+                Hint::Unknown(magic) => Ok(Object::Unknown(magic))
+            }
         }
     }
-}
+} // end if_endian_fd
 
 /////////////////////////
 // Binary Modules
@@ -334,11 +365,11 @@ pub mod elf64 {
     }
 }
 
-#[cfg(all(feature = "mach32", feature = "mach64", feature = "endian_fd"))]
+#[cfg(any(feature = "mach32", feature = "mach64"))]
 pub mod mach;
 
-#[cfg(all(feature = "pe32", feature = "pe64", feature = "endian_fd"))]
+#[cfg(any(feature = "pe32", feature = "pe64"))]
 pub mod pe;
 
-#[cfg(all(feature = "archive", feature = "std"))]
+#[cfg(feature = "archive")]
 pub mod archive;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,14 +125,6 @@ macro_rules! if_alloc {
     )*)
 }
 
-#[allow(unused)]
-macro_rules! if_endian_fd {
-    ($($i:item)*) => ($(
-        #[cfg(feature = "endian_fd")]
-        $i
-    )*)
-}
-
 #[cfg(feature = "alloc")]
 pub mod error;
 
@@ -220,6 +212,13 @@ pub mod container {
             Ctx { container: Container::default(), le: scroll::Endian::default() }
         }
     }
+}
+
+macro_rules! if_endian_fd {
+    ($($i:item)*) => ($(
+        #[cfg(all(feature = "endian_fd", feature = "elf64", feature = "elf32", feature = "pe64", feature = "pe32", feature = "mach64", feature = "mach32", feature = "archive"))]
+        $i
+    )*)
 }
 
 if_endian_fd! {

--- a/src/mach/exports.rs
+++ b/src/mach/exports.rs
@@ -11,6 +11,8 @@ use scroll::{self, Pread, Uleb128};
 use error;
 use core::fmt::{self, Debug};
 use mach::load_command;
+use alloc::vec::Vec;
+use alloc::string::String;
 
 type Flag = u64;
 

--- a/src/mach/fat.rs
+++ b/src/mach/fat.rs
@@ -2,8 +2,10 @@
 
 use core::fmt;
 
-use std::fs::File;
-use std::io::{self, Read};
+if_std! {
+    use std::fs::File;
+    use std::io::{self, Read};
+}
 
 use scroll::{self, Pread};
 use mach::constants::cputype::{CpuType, CpuSubType, CPU_SUBTYPE_MASK, CPU_ARCH_ABI64};
@@ -13,8 +15,7 @@ pub const FAT_MAGIC: u32 = 0xcafebabe;
 pub const FAT_CIGAM: u32 = 0xbebafeca;
 
 #[repr(C)]
-#[derive(Clone, Copy, Default)]
-#[cfg_attr(feature = "std", derive(Pread, Pwrite, SizeWith))]
+#[derive(Clone, Copy, Default, Pread, Pwrite, SizeWith)]
 /// The Mach-o `FatHeader` always has its data bigendian
 pub struct FatHeader {
     /// The magic number, `cafebabe`
@@ -44,6 +45,7 @@ impl FatHeader {
     }
 
     /// Reads a `FatHeader` from a `File` on disk
+    #[cfg(feature = "std")]
     pub fn from_fd(fd: &mut File) -> io::Result<FatHeader> {
         let mut header = [0; SIZEOF_FAT_HEADER];
         try!(fd.read(&mut header));
@@ -58,8 +60,7 @@ impl FatHeader {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Default)]
-#[cfg_attr(feature = "std", derive(Pread, Pwrite, SizeWith))]
+#[derive(Clone, Copy, Default, Pread, Pwrite, SizeWith)]
 /// The Mach-o `FatArch` always has its data bigendian
 pub struct FatArch {
     /// What kind of CPU this binary is

--- a/src/mach/header.rs
+++ b/src/mach/header.rs
@@ -1,6 +1,6 @@
 //! A header contains minimal architecture information, the binary kind, the number of load commands, as well as an endianness hint
 
-use std::fmt;
+use core::fmt;
 use scroll::{ctx, Pwrite, Pread};
 use scroll::ctx::SizeWith;
 use plain::{self, Plain};

--- a/src/mach/imports.rs
+++ b/src/mach/imports.rs
@@ -7,6 +7,7 @@
 use core::ops::Range;
 use core::fmt::{self, Debug};
 use scroll::{Sleb128, Uleb128, Pread};
+use alloc::vec::Vec;
 
 use container;
 use error;

--- a/src/mach/load_command.rs
+++ b/src/mach/load_command.rs
@@ -1,7 +1,7 @@
 //! Load commands tell the kernel and dynamic linker anything from how to load this binary into memory, what the entry point is, apple specific information, to which libraries it requires for dynamic linking
 
 use error;
-use std::fmt::{self, Display};
+use core::fmt::{self, Display};
 use scroll::{self, ctx, Endian, Pread};
 
 ///////////////////////////////////////
@@ -539,7 +539,6 @@ impl Clone for ThreadCommand {
     }
 }
 
-#[cfg(feature = "std")]
 impl fmt::Debug for ThreadCommand {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.debug_struct("ThreadCommand")

--- a/src/mach/mod.rs
+++ b/src/mach/mod.rs
@@ -1,5 +1,6 @@
 //! The Mach-o, mostly zero-copy, binary format parser and raw struct definitions
 use core::fmt;
+use alloc::vec::Vec;
 
 use scroll::{self, Pread, BE};
 use scroll::ctx::SizeWith;
@@ -70,7 +71,6 @@ pub struct MachO<'a> {
     bind_interpreter: Option<imports::BindInterpreter<'a>>,
 }
 
-#[cfg(feature = "std")]
 impl<'a> fmt::Debug for MachO<'a> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.debug_struct("MachO")
@@ -239,7 +239,6 @@ impl<'a> MachO<'a> {
     }
 }
 
-#[cfg(feature = "std")]
 /// A Mach-o multi architecture (Fat) binary container
 pub struct MultiArch<'a> {
     data: &'a [u8],
@@ -311,7 +310,6 @@ impl<'a, 'b> IntoIterator for &'b MultiArch<'a> {
     }
 }
 
-#[cfg(feature = "std")]
 impl<'a> MultiArch<'a> {
     /// Lazily construct `Self`
     pub fn new(bytes: &'a [u8]) -> error::Result<Self> {
@@ -368,7 +366,6 @@ impl<'a> MultiArch<'a> {
     }
 }
 
-#[cfg(feature = "std")]
 impl<'a> fmt::Debug for MultiArch<'a> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.debug_struct("MultiArch")

--- a/src/mach/segment.rs
+++ b/src/mach/segment.rs
@@ -1,8 +1,10 @@
 use scroll::{self, Pread, Pwrite};
 use scroll::ctx::{self, SizeWith};
 
-use std::fmt;
-use std::ops::{Deref, DerefMut};
+use core::fmt;
+use core::ops::{Deref, DerefMut};
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 
 use container;
 use error;
@@ -220,7 +222,7 @@ pub struct SectionIterator<'a> {
 
 pub type SectionData<'a> = &'a [u8];
 
-impl<'a> ::std::iter::ExactSizeIterator for SectionIterator<'a> {
+impl<'a> ::core::iter::ExactSizeIterator for SectionIterator<'a> {
     fn len(&self) -> usize {
         self.count
     }
@@ -484,7 +486,7 @@ impl<'a> DerefMut for Segments<'a> {
 
 impl<'a, 'b> IntoIterator for &'b Segments<'a> {
     type Item = &'b Segment<'a>;
-    type IntoIter = ::std::slice::Iter<'b, Segment<'a>>;
+    type IntoIter = ::core::slice::Iter<'b, Segment<'a>>;
     fn into_iter(self) -> Self::IntoIter {
         self.segments.iter()
     }

--- a/src/pe/export.rs
+++ b/src/pe/export.rs
@@ -1,4 +1,5 @@
 use scroll::{self, Pread};
+use alloc::vec::Vec;
 
 use error;
 

--- a/src/pe/import.rs
+++ b/src/pe/import.rs
@@ -1,4 +1,5 @@
-use std::borrow::Cow;
+use alloc::borrow::Cow;
+use alloc::vec::Vec;
 
 use scroll::{self, Pread};
 use error;

--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -3,6 +3,8 @@
 
 // TODO: panics with unwrap on None for apisetschema.dll, fhuxgraphics.dll and some others
 
+use alloc::vec::Vec;
+
 pub mod header;
 pub mod optional_header;
 pub mod characteristic;

--- a/src/pe/utils.rs
+++ b/src/pe/utils.rs
@@ -1,4 +1,5 @@
 use scroll::{Pread};
+use alloc::string::ToString;
 use error;
 
 use super::section_table;


### PR DESCRIPTION
This allows building the `endian_fd` feature without `std`, although it does still require the `alloc` crate and a nightly rustc.

Fixes #75 