### PR TITLE
Fix parsing of PE32+ import tables

### DIFF
--- a/src/pe/import.rs
+++ b/src/pe/import.rs
@@ -15,8 +15,6 @@ pub const IMPORT_BY_ORDINAL_32: u32 = 0x8000_0000;
 pub const IMPORT_BY_ORDINAL_64: u64 = 0x8000_0000_0000_0000;
 pub const IMPORT_RVA_MASK_32: u32 = 0x8fff_ffff;
 pub const IMPORT_RVA_MASK_64: u64 = 0x0000_0000_8fff_ffff;
-pub const SIZEOF_IMPORT_ADDRESS_TABLE_ENTRY_32: usize = 4;
-pub const SIZEOF_IMPORT_ADDRESS_TABLE_ENTRY_64: usize = 8;
 
 pub trait Bitfield<'a>: PartialEq + Eq + LowerHex + Debug + TryFromCtx<'a, scroll::Endian, Error=scroll::Error, Size=usize> {
     fn is_ordinal(&self) -> bool;

--- a/src/pe/import.rs
+++ b/src/pe/import.rs
@@ -16,13 +16,12 @@ pub const IMPORT_BY_ORDINAL_64: u64 = 0x8000_0000_0000_0000;
 pub const IMPORT_RVA_MASK_32: u32 = 0x8fff_ffff;
 pub const IMPORT_RVA_MASK_64: u64 = 0x0000_0000_8fff_ffff;
 
-pub trait Bitfield<'a>: PartialEq + Eq + LowerHex + Debug + TryFromCtx<'a, scroll::Endian, Error=scroll::Error, Size=usize> {
+pub trait Bitfield<'a>: Into<u64> + PartialEq + Eq + LowerHex + Debug + TryFromCtx<'a, scroll::Endian, Error=scroll::Error, Size=usize> {
     fn is_ordinal(&self) -> bool;
     fn to_ordinal(&self) -> u16;
     fn to_rva(&self) -> u32;
     fn size_of() -> usize;
     fn is_zero(&self) -> bool;
-    fn vec_to_import_address_table(Vec<Self>) -> ImportAddressTable;
 }
 
 impl<'a> Bitfield<'a> for u64 {
@@ -31,7 +30,6 @@ impl<'a> Bitfield<'a> for u64 {
     fn to_rva(&self) -> u32 { (self & IMPORT_RVA_MASK_64) as u32 }
     fn size_of() -> usize { 8 }
     fn is_zero(&self) -> bool { *self == 0 }
-    fn vec_to_import_address_table(table: Vec<u64>) -> ImportAddressTable { ImportAddressTable::PE64(table) }
 }
 
 impl<'a> Bitfield<'a> for u32 {
@@ -40,7 +38,6 @@ impl<'a> Bitfield<'a> for u32 {
     fn to_rva(&self) -> u32 { (self & IMPORT_RVA_MASK_32) as u32 }
     fn size_of() -> usize { 4 }
     fn is_zero(&self) -> bool { *self == 0 }
-    fn vec_to_import_address_table(table: Vec<u32>) -> ImportAddressTable { ImportAddressTable::PE32(table) }
 }
 
 #[derive(Debug, Clone)]
@@ -108,11 +105,7 @@ impl<'a> SyntheticImportLookupTableEntry<'a> {
 }
 
 // get until entry is 0
-#[derive(Debug)]
-pub enum ImportAddressTable {
-    PE32(Vec<u32>),
-    PE64(Vec<u64>)
-}
+pub type ImportAddressTable = Vec<u64>;
 
 #[repr(C)]
 #[derive(Debug)]
@@ -168,14 +161,14 @@ impl<'a> SyntheticImportDirectoryEntry<'a> {
         let import_address_table_offset = &mut utils::find_offset(import_directory_entry.import_address_table_rva as usize, sections).ok_or(error::Error::Malformed(format!("Cannot map import_address_table_rva {:#x} into offset for {}", import_directory_entry.import_address_table_rva, name)))?;
         let mut import_address_table = Vec::new();
         loop {
-            let import_address: T = bytes.gread_with(import_address_table_offset, LE)?;
-            if import_address.is_zero() { break } else { import_address_table.push(import_address); }
+            let import_address = bytes.gread_with::<T>(import_address_table_offset, LE)?.into();
+            if import_address == 0 { break } else { import_address_table.push(import_address); }
         }
         Ok(SyntheticImportDirectoryEntry {
             import_directory_entry: import_directory_entry,
             name: name,
             import_lookup_table: import_lookup_table,
-            import_address_table: T::vec_to_import_address_table(import_address_table)
+            import_address_table: import_address_table
         })
     }
 }

--- a/src/pe/import.rs
+++ b/src/pe/import.rs
@@ -1,12 +1,46 @@
 use alloc::borrow::Cow;
 use alloc::vec::Vec;
+use core::fmt::{LowerHex, Debug};
 
 use scroll::{self, Pread};
+use scroll::ctx::TryFromCtx;
 use error;
 
 use pe::section_table;
 use pe::utils;
 use pe::data_directories;
+
+
+pub const IMPORT_BY_ORDINAL_32: u32 = 0x8000_0000;
+pub const IMPORT_BY_ORDINAL_64: u64 = 0x8000_0000_0000_0000;
+pub const IMPORT_RVA_MASK_32: u32 = 0x8fff_ffff;
+pub const IMPORT_RVA_MASK_64: u64 = 0x0000_0000_8fff_ffff;
+pub const SIZEOF_IMPORT_ADDRESS_TABLE_ENTRY_32: usize = 4;
+pub const SIZEOF_IMPORT_ADDRESS_TABLE_ENTRY_64: usize = 8;
+
+pub trait Bitfield<'a>: PartialEq + Eq + LowerHex + Debug + TryFromCtx<'a, scroll::Endian, Error=scroll::Error, Size=usize> {
+    fn is_ordinal(&self) -> bool;
+    fn to_ordinal(&self) -> u16;
+    fn to_rva(&self) -> usize;
+    fn size_of() -> usize;
+    fn is_zero(&self) -> bool;
+}
+
+impl<'a> Bitfield<'a> for u64 {
+    fn is_ordinal(&self) -> bool { self & IMPORT_BY_ORDINAL_64 == IMPORT_BY_ORDINAL_64 }
+    fn to_ordinal(&self) -> u16 { (0xffff & self) as u16 }
+    fn to_rva(&self) -> usize { (self & IMPORT_RVA_MASK_64) as usize }
+    fn size_of() -> usize { 8 }
+    fn is_zero(&self) -> bool { *self == 0}
+}
+
+impl<'a> Bitfield<'a> for u32 {
+    fn is_ordinal(&self) -> bool { self & IMPORT_BY_ORDINAL_32 == IMPORT_BY_ORDINAL_32 }
+    fn to_ordinal(&self) -> u16 { (0xffff & self) as u16 }
+    fn to_rva(&self) -> usize { (self & IMPORT_RVA_MASK_32) as usize }
+    fn size_of() -> usize { 4 }
+    fn is_zero(&self) -> bool { *self == 0}
+}
 
 #[derive(Debug, Clone)]
 pub struct HintNameTableEntry<'a> {
@@ -26,41 +60,37 @@ impl<'a> HintNameTableEntry<'a> {
 #[derive(Debug, Clone)]
 pub enum SyntheticImportLookupTableEntry<'a> {
     OrdinalNumber(u16),
-    HintNameTableRVA ((u32, HintNameTableEntry<'a>)), // [u8; 31] bitfield :/
+    HintNameTableRVA ((usize, HintNameTableEntry<'a>)), // [u8; 31] bitfield :/
 }
 
 #[derive(Debug)]
 pub struct ImportLookupTableEntry<'a> {
-    pub bitfield: u32,
     pub synthetic: SyntheticImportLookupTableEntry<'a>,
 }
 
 pub type ImportLookupTable<'a> = Vec<ImportLookupTableEntry<'a>>;
 
-pub const IMPORT_BY_ORDINAL_32: u32 = 0x8000_0000;
-pub const IMPORT_RVA_MASK_32: u32 = 0x8fff_ffff;
-
 impl<'a> ImportLookupTableEntry<'a> {
-    pub fn parse(bytes: &'a [u8], mut offset: usize, sections: &[section_table::SectionTable])
+    pub fn parse<T: Bitfield<'a>>(bytes: &'a [u8], mut offset: usize, sections: &[section_table::SectionTable])
                                                                       -> error::Result<ImportLookupTable<'a>> {
         let le = scroll::LE;
         let offset = &mut offset;
         let mut table = Vec::new();
         loop {
-            let bitfield: u32 = bytes.gread_with(offset, le)?;
-            if bitfield == 0 {
+            let bitfield: T = bytes.gread_with(offset, le)?;
+            if bitfield.is_zero() {
                 debug!("imports done");
                 break;
             } else {
                 let synthetic = {
                     debug!("bitfield {:#x}", bitfield);
                     use self::SyntheticImportLookupTableEntry::*;
-                    if bitfield & IMPORT_BY_ORDINAL_32 == IMPORT_BY_ORDINAL_32 {
-                        let ordinal = (0xffff & bitfield) as u16;
+                    if bitfield.is_ordinal() {
+                        let ordinal = bitfield.to_ordinal();
                         debug!("importing by ordinal {:#x}", ordinal);
                         OrdinalNumber(ordinal)
                     } else {
-                        let rva = bitfield & IMPORT_RVA_MASK_32;
+                        let rva = bitfield.to_rva();
                         let hentry = {
                             debug!("searching for RVA {:#x}", rva);
                             if let Some(offset) = utils::find_offset(rva as usize, sections) {
@@ -74,7 +104,7 @@ impl<'a> ImportLookupTableEntry<'a> {
                         HintNameTableRVA ((rva, hentry))
                     }
                 };
-                let entry = ImportLookupTableEntry { bitfield: bitfield, synthetic: synthetic };
+                let entry = ImportLookupTableEntry { synthetic: synthetic };
                 table.push(entry);
             }
         }
@@ -83,9 +113,7 @@ impl<'a> ImportLookupTableEntry<'a> {
 }
 
 // get until entry is 0
-pub type ImportAddressTable = Vec<u32>;
-
-pub const SIZEOF_IMPORT_ADDRESS_TABLE_ENTRY: usize = 4;
+pub type ImportAddressTable = Vec<usize>;
 
 #[repr(C)]
 #[derive(Debug)]
@@ -122,7 +150,7 @@ pub struct SyntheticImportDirectoryEntry<'a> {
 }
 
 impl<'a> SyntheticImportDirectoryEntry<'a> {
-    pub fn parse(bytes: &'a [u8], import_directory_entry: ImportDirectoryEntry, sections: &[section_table::SectionTable]) -> error::Result<SyntheticImportDirectoryEntry<'a>> {
+    pub fn parse<T: Bitfield<'a>>(bytes: &'a [u8], import_directory_entry: ImportDirectoryEntry, sections: &[section_table::SectionTable]) -> error::Result<SyntheticImportDirectoryEntry<'a>> {
         const LE: scroll::Endian = scroll::LE;
         let name_rva = import_directory_entry.name_rva;
         let name = utils::try_name(bytes, name_rva as usize, sections)?;
@@ -130,13 +158,14 @@ impl<'a> SyntheticImportDirectoryEntry<'a> {
             let import_lookup_table_rva = import_directory_entry.import_lookup_table_rva;
             debug!("Synthesizing lookup table imports for {} lib, with import lookup table rva: {:#x}", name, import_lookup_table_rva);
             if let Some(import_lookup_table_offset) = utils::find_offset(import_lookup_table_rva as usize, sections) {
-                let import_lookup_table = ImportLookupTableEntry::parse(bytes, import_lookup_table_offset, sections)?;
+                let import_lookup_table = ImportLookupTableEntry::parse::<T>(bytes, import_lookup_table_offset, sections)?;
                 debug!("Successfully synthesized import lookup table entry: {:#?}", import_lookup_table);
                 Some(import_lookup_table)
             } else {
                 None
             }
         };
+
         let import_address_table_offset = &mut utils::find_offset(import_directory_entry.import_address_table_rva as usize, sections).ok_or(error::Error::Malformed(format!("Cannot map import_address_table_rva {:#x} into offset for {}", import_directory_entry.import_address_table_rva, name)))?;
         let mut import_address_table = Vec::new();
         loop {
@@ -159,7 +188,7 @@ pub struct ImportData<'a> {
 }
 
 impl<'a> ImportData<'a> {
-    pub fn parse(bytes: &'a[u8], dd: &data_directories::DataDirectory, sections: &[section_table::SectionTable]) -> error::Result<ImportData<'a>> {
+    pub fn parse<T: Bitfield<'a>>(bytes: &'a[u8], dd: &data_directories::DataDirectory, sections: &[section_table::SectionTable]) -> error::Result<ImportData<'a>> {
         let import_directory_table_rva = dd.virtual_address as usize;
         debug!("import_directory_table_rva {:#x}", import_directory_table_rva);
         let offset = &mut utils::find_offset(import_directory_table_rva, sections).ok_or(error::Error::Malformed(format!("Cannot create ImportData; cannot map import_directory_table_rva {:#x} into offset", import_directory_table_rva)))?;;
@@ -171,7 +200,7 @@ impl<'a> ImportData<'a> {
             if import_directory_entry.is_null() {
                 break;
             } else {
-                let entry = SyntheticImportDirectoryEntry::parse(bytes, import_directory_entry, sections)?;
+                let entry = SyntheticImportDirectoryEntry::parse::<T>(bytes, import_directory_entry, sections)?;
                 debug!("entry {:#?}", entry);
                 import_data.push(entry);
             }
@@ -193,7 +222,7 @@ pub struct Import<'a> {
 }
 
 impl<'a> Import<'a> {
-    pub fn parse(_bytes: &'a [u8], import_data: &ImportData<'a>, _sections: &[section_table::SectionTable]) -> error::Result<Vec<Import<'a>>> {
+    pub fn parse<T: Bitfield<'a>>(_bytes: &'a [u8], import_data: &ImportData<'a>, _sections: &[section_table::SectionTable]) -> error::Result<Vec<Import<'a>>> {
         let mut imports = Vec::new();
         for data in &import_data.import_data {
             if let Some(ref import_lookup_table) = data.import_lookup_table {
@@ -201,7 +230,7 @@ impl<'a> Import<'a> {
                 let import_base = data.import_directory_entry.import_address_table_rva as usize;
                 debug!("Getting imports from {}", &dll);
                 for (i, entry) in import_lookup_table.iter().enumerate() {
-                    let offset = import_base + (i * SIZEOF_IMPORT_ADDRESS_TABLE_ENTRY);
+                    let offset = import_base + (i * T::size_of());
                     use self::SyntheticImportLookupTableEntry::*;
                     let (rva, name, ordinal) =
                         match &entry.synthetic {
@@ -214,13 +243,13 @@ impl<'a> Import<'a> {
                             &OrdinalNumber(ordinal) => {
                                 let name = format!("ORDINAL {}", ordinal);
                                 (0x0, Cow::Owned(name), ordinal)
-                            }
+                            },
                         };
                     let import =
                         Import {
                             name: name,
                             ordinal: ordinal, dll: dll,
-                            size: 4, offset: offset, rva: rva as usize
+                            size: T::size_of(), offset: offset, rva: rva as usize
                         };
                     imports.push(import);
                 }

--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -90,9 +90,10 @@ impl<'a> PE<'a> {
             }
             debug!("exports: {:#?}", exports);
             if let &Some(import_table) = optional_header.data_directories.get_import_table() {
-                let id = match is_64 {
-                    true => import::ImportData::parse::<u64>(bytes, &import_table, &sections)?,
-                    false => import::ImportData::parse::<u32>(bytes, &import_table, &sections)?
+                let id = if is_64 {
+                    import::ImportData::parse::<u64>(bytes, &import_table, &sections)?
+                } else {
+                    import::ImportData::parse::<u32>(bytes, &import_table, &sections)?
                 };
                 debug!("import data {:#?}", id);
                 if is_64 {

--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -90,9 +90,16 @@ impl<'a> PE<'a> {
             }
             debug!("exports: {:#?}", exports);
             if let &Some(import_table) = optional_header.data_directories.get_import_table() {
-                let id = import::ImportData::parse(bytes, &import_table, &sections)?;
+                let id = match is_64 {
+                    true => import::ImportData::parse::<u64>(bytes, &import_table, &sections)?,
+                    false => import::ImportData::parse::<u32>(bytes, &import_table, &sections)?
+                };
                 debug!("import data {:#?}", id);
-                imports = import::Import::parse(bytes, &id, &sections)?;
+                if is_64 {
+                    imports = import::Import::parse::<u64>(bytes, &id, &sections)?
+                } else {
+                    imports = import::Import::parse::<u32>(bytes, &id, &sections)?
+                }
                 libraries = id.import_data.iter().map( | data | { data.name }).collect::<Vec<&'a str>>();
                 libraries.sort();
                 libraries.dedup();


### PR DESCRIPTION
I noticed that only the first imported symbol from each library is being parsed in 64-bit PEs. This is one way to fix it.