### PR TITLE
Parsing PE export

### DIFF
--- a/src/pe/export.rs
+++ b/src/pe/export.rs
@@ -56,11 +56,11 @@ pub type ExportOrdinalTable = Vec<u16>;
 #[derive(Debug, Default)]
 /// Export data contains the `dll` name which other libraries can import symbols by (two-level namespace), as well as other important indexing data allowing symbol lookups
 pub struct ExportData<'a> {
-    pub name: &'a str,
+    pub name: Option<&'a str>,
     pub export_directory_table: ExportDirectoryTable,
-    pub export_name_pointer_table: ExportNamePointerTable,
-    pub export_ordinal_table: ExportOrdinalTable,
-    pub export_address_table: ExportAddressTable,
+    pub export_name_pointer_table: Option<ExportNamePointerTable>,
+    pub export_ordinal_table: Option<ExportOrdinalTable>,
+    pub export_address_table: Option<ExportAddressTable>,
 }
 
 impl<'a> ExportData<'a> {
@@ -68,40 +68,67 @@ impl<'a> ExportData<'a> {
         let export_rva = dd.virtual_address as usize;
         let size = dd.size as usize;
         debug!("export_rva {:#x} size {:#}", export_rva, size);
-        let export_offset = utils::find_offset_or(export_rva, sections, &format!("Cannot map export_rva ({:#x}) into offset", export_rva))?;
-        let export_directory_table = ExportDirectoryTable::parse(bytes, export_offset)?;
+        let export_offset = utils::find_offset_or(export_rva, sections, &format!("cannot map export_rva ({:#x}) into offset", export_rva))?;
+        let export_directory_table = ExportDirectoryTable::parse(bytes, export_offset)
+            .map_err(|_| error::Error::Malformed(format!("cannot parse export_directory_table (offset {:#x})", export_offset)))?;
         let number_of_name_pointers = export_directory_table.number_of_name_pointers as usize;
         let address_table_entries = export_directory_table.address_table_entries as usize;
-        //let ordinal_base = export_directory_table.ordinal_base as usize;
 
-        let name_pointer_table_offset = &mut utils::find_offset_or(export_directory_table.name_pointer_rva as usize, sections, &format!("Cannot map export_directory_table.name_pointer_rva ({:#x}) into offset", export_directory_table.name_pointer_rva))?;
-        let mut export_name_pointer_table: ExportNamePointerTable = Vec::with_capacity(number_of_name_pointers);
-        for _ in 0..number_of_name_pointers {
-            export_name_pointer_table.push(bytes.gread_with(name_pointer_table_offset, scroll::LE)?);
-        }
+        let export_name_pointer_table = utils::find_offset(export_directory_table.name_pointer_rva as usize, sections).map(|table_offset| {
+            let mut offset = table_offset;
+            let mut table: ExportNamePointerTable = Vec::with_capacity(number_of_name_pointers);
 
-        let export_ordinal_table_offset = &mut utils::find_offset_or(export_directory_table.ordinal_table_rva as usize, sections, &format!("Cannot map export_directory_table.ordinal_table_rva ({:#x}) into offset", export_directory_table.ordinal_table_rva))?;
-        let mut export_ordinal_table: ExportOrdinalTable = Vec::with_capacity(number_of_name_pointers);
-        for _ in 0..number_of_name_pointers {
-            export_ordinal_table.push(bytes.gread_with(export_ordinal_table_offset, scroll::LE)?);
-        }
-
-        let export_address_table_offset = utils::find_offset_or(export_directory_table.export_address_table_rva as usize, sections, &format!("Cannot map export_directory_table.export_address_table_rva ({:#x}) into offset", export_directory_table.export_address_table_rva))?;
-        let export_end = export_rva + size;
-        let offset = &mut export_address_table_offset.clone();
-        let mut export_address_table: ExportAddressTable = Vec::with_capacity(address_table_entries);
-        for _ in 0..address_table_entries {
-            let rva: u32 = bytes.gread_with(offset, scroll::LE)?;
-            if utils::is_in_range(rva as usize, export_rva, export_end) {
-                export_address_table.push(ExportAddressTableEntry::ForwarderRVA(rva));
-            } else {
-                export_address_table.push(ExportAddressTableEntry::ExportRVA(rva));
+            for _ in 0..number_of_name_pointers {
+                if let Ok(name_rva) = bytes.gread_with(&mut offset, scroll::LE) {
+                    table.push(name_rva);
+                }
+                else {
+                    break;
+                }
             }
-        }
 
-        let name_offset = utils::find_offset_or(export_directory_table.name_rva as usize, sections, &format!("Cannot map export_directory_table.name_rva ({:#x}) into offset", export_directory_table.name_rva))?;
-        debug!("ExportData.parse pointers: {:#x} ordinals: {:#x} addresses: {:#x}", name_pointer_table_offset, export_ordinal_table_offset, export_address_table_offset);
-        let name: &'a str = bytes.pread(name_offset)?;
+            table
+        });
+
+        let export_ordinal_table = utils::find_offset(export_directory_table.ordinal_table_rva as usize, sections).map(|table_offset| {
+            let mut offset = table_offset;
+            let mut table: ExportOrdinalTable = Vec::with_capacity(number_of_name_pointers);
+
+            for _ in 0..number_of_name_pointers {
+                if let Ok(name_ordinal) = bytes.gread_with(&mut offset, scroll::LE) {
+                    table.push(name_ordinal);
+                }
+                else {
+                    break;
+                }
+            }
+
+            table
+        });
+
+        let export_address_table = utils::find_offset(export_directory_table.export_address_table_rva as usize, sections).map(|table_offset| {
+            let mut offset = table_offset;
+            let mut table: ExportAddressTable = Vec::with_capacity(address_table_entries);
+            let export_end = export_rva + size;
+
+            for _ in 0..address_table_entries {
+                if let Ok(func_rva) = bytes.gread_with::<u32>(&mut offset, scroll::LE) {
+                    if utils::is_in_range(func_rva as usize, export_rva, export_end) {
+                        table.push(ExportAddressTableEntry::ForwarderRVA(func_rva));
+                    } else {
+                        table.push(ExportAddressTableEntry::ExportRVA(func_rva));
+                    }
+                }
+                else {
+                    break;
+                }
+            }
+
+            table
+        });
+
+        let name = utils::find_offset(export_directory_table.name_rva as usize, sections).and_then(|offset| bytes.pread(offset).ok());
+
         Ok(ExportData {
             name: name,
             export_directory_table: export_directory_table,
@@ -173,16 +200,16 @@ impl<'a> Reexport<'a> {
 #[derive(Debug, Default)]
 /// An exported symbol in this binary, contains synthetic data (name offset, etc., are computed)
 pub struct Export<'a> {
-    pub name: &'a str,
-    pub offset: usize,
-    pub rva: usize,
-    pub size: usize,
+    pub name: Option<&'a str>,
+    pub offset: Option<usize>,
+    pub rva: Option<usize>,
+    // pub size: usize,
     pub reexport: Option<Reexport<'a>>,
 }
 
 #[derive(Debug, Copy, Clone)]
 struct ExportCtx<'a> {
-    pub ptr: u32,
+    pub ptr: Option<u32>,
     pub idx: usize,
     pub sections: &'a [section_table::SectionTable],
     pub addresses: &'a ExportAddressTable,
@@ -195,31 +222,39 @@ impl<'a, 'b> scroll::ctx::TryFromCtx<'a, ExportCtx<'b>> for Export<'a> {
     #[inline]
     fn try_from_ctx(bytes: &'a [u8], ExportCtx { ptr, idx, sections, addresses, ordinals }: ExportCtx<'b>) -> Result<(Self, Self::Size), Self::Error> {
         use self::ExportAddressTableEntry::*;
-        let i = idx;
-        let name_offset = utils::find_offset_or(ptr as usize, sections, &format!("Cannot map export name pointer rva ({:#x}) into offset", ptr))?;
-        let name = bytes.pread::<&str>(name_offset)?;
-        let ordinal = ordinals[i];
-        let address_index = ordinal as usize;
-        debug!("name: {} name_offset: {:#x} ordinal: {} address_index: {}", name, name_offset, ordinal, address_index);
-        if address_index >= addresses.len() {
-            debug!("Export.pread bad address index ({}) for {}: idx: {} ordinal: {} addresses.len(): {}", name, address_index, i, ordinal, addresses.len());
-            Ok((Export::default(), 0))
-        } else {
-            match addresses[address_index] {
-                ExportRVA(rva) => {
-                    let rva = rva as usize;
-                    let offset = utils::find_offset_or(rva, sections, &format!("Cannot map export rva ({:#x}) into offset for {}", rva, name))?;
-                    debug!("{}: {:#x}", name, offset);
-                    Ok((Export { name: name, offset: offset, rva: rva, reexport: None, size: 0 }, 0))
-                },
-                ForwarderRVA(rva) => {
-                    let rva = rva as usize;
-                    let offset = utils::find_offset_or(rva, sections, &format!("Cannot map forwarder rva ({:#x}) into offset for {}", rva, name))?;
-                    debug!("{}: stroffset {:#x}", name, offset);
-                    let reexport = Reexport::parse(bytes, offset)?;
-                    debug!("{}: reexport {:?}", name, reexport);
-                    Ok((Export { name: name, offset: rva, rva: rva, reexport: Some(reexport), size: 0 }, 0))
-                },
+        
+        let name = ptr.map_or(None, |ptr| {
+            let name_offset = utils::find_offset(ptr as usize, sections);
+            name_offset.and_then(|offset| bytes.pread::<&str>(offset).ok())
+        });
+
+        let ordinal = ordinals.get(idx);
+        match ordinal {
+            Some(&address_index) => {
+                let address_index = address_index as usize;
+                if address_index >= addresses.len() {
+                    Ok((Export { name: name, offset: None, rva: None, reexport: None }, 0))
+                }
+                else {
+                    match addresses[address_index] {
+                        ExportRVA(rva) => {
+                            let rva = rva as usize;
+                            let offset = utils::find_offset(rva, sections);
+                            Ok((Export { name: name, offset: offset, rva: Some(rva), reexport: None }, 0))
+                        },
+
+                        ForwarderRVA(rva) => {
+                            let rva = rva as usize;
+                            let offset = utils::find_offset(rva, sections);
+                            let reexport = offset.and_then(|offset| Reexport::parse(bytes, offset).ok());
+                            Ok((Export { name: name, offset: offset, rva: Some(rva), reexport }, 0))
+                        }
+                    }
+                }
+            },
+
+            None => {
+                Ok((Export { name: name, offset: None, rva: None, reexport: None}, 0))
             }
         }
     }
@@ -227,15 +262,29 @@ impl<'a, 'b> scroll::ctx::TryFromCtx<'a, ExportCtx<'b>> for Export<'a> {
 
 impl<'a> Export<'a> {
     pub fn parse(bytes: &'a [u8], export_data: &ExportData, sections: &[section_table::SectionTable]) -> error::Result<Vec<Export<'a>>> {
-        let pointers = &export_data.export_name_pointer_table;
-        let addresses = &export_data.export_address_table;
-        let ordinals = &export_data.export_ordinal_table;
-        //let ordinal_base = export_data.export_directory_table.ordinal_base as usize;
-        let mut exports = Vec::with_capacity(pointers.len());
-        for (idx, ptr) in pointers.iter().enumerate() {
-            let export = bytes.pread_with(0, ExportCtx { ptr: *ptr, idx: idx, sections: sections, addresses: addresses, ordinals: ordinals })?;
+        let number_of_name_pointers = export_data.export_directory_table.number_of_name_pointers;
+
+        let mut addresses = &Vec::new();
+        if let Some(ref table) = export_data.export_address_table {
+            addresses = table;
+        }
+
+        let mut ordinals = &Vec::new();
+        if let Some(ref table) = export_data.export_ordinal_table {
+            ordinals = table;
+        }
+
+        let mut exports = Vec::with_capacity(number_of_name_pointers as usize);
+        for idx in 0..number_of_name_pointers {
+            let ptr = export_data.export_name_pointer_table.as_ref().map_or(None, |pointers| {
+                pointers.get(idx as usize).map(|v| *v)
+            });
+
+            let export = bytes.pread_with(0, ExportCtx { ptr: ptr, idx: idx as usize, sections: sections, addresses: addresses, ordinals: ordinals })?;
             exports.push(export);
         }
+
+
         // TODO: sort + compute size
         Ok (exports)
     }
@@ -244,9 +293,104 @@ impl<'a> Export<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use self::data_directories::*;
+
+    static CORKAMI_POCS_PE_EXPORTSDATA_EXE: [u8; 0x400] =
+        [ 0x4d, 0x5a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00,
+          0x50, 0x45, 0x00, 0x00, 0x4c, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0xe0, 0x00, 0x02, 0x01, 0x0b, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x10, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x20, 0x00, 0x00, 0x60, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0xb0, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x48, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x10, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xa0,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x80, 0x01, 0x00, 0x00, 0x80, 0x02, 0x00, 0x00, 0x80, 0x03, 0x00, 0x00, 0x80,
+          0x00, 0x00, 0x00, 0x00, 0x20, 0x2a, 0x20, 0x64, 0x61, 0x74, 0x61, 0x20, 0x73, 0x74, 0x6f, 0x72,
+          0x65, 0x64, 0x20, 0x61, 0x73, 0x20, 0x66, 0x61, 0x6b, 0x65, 0x20, 0x65, 0x78, 0x70, 0x6f, 0x72,
+          0x74, 0x20, 0x74, 0x61, 0x62, 0x6c, 0x65, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x8c, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x84, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x95, 0x10, 0x00, 0x00, 0x40, 0x10, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xa0, 0x10, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x8c, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x70, 0x72,
+          0x69, 0x6e, 0x74, 0x66, 0x00, 0x6d, 0x73, 0x76, 0x63, 0x72, 0x74, 0x2e, 0x64, 0x6c, 0x6c, 0x00,
+          0x65, 0x78, 0x70, 0x6f, 0x72, 0x74, 0x73, 0x64, 0x61, 0x74, 0x61, 0x2e, 0x65, 0x78, 0x65, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xe0, 0x10, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x68, 0x14, 0x10, 0xf0, 0x10, 0xff, 0x15, 0x30, 0x10, 0x00, 0x10, 0x73, 0xc4, 0x04, 0xc3, 0xbc,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x01, 0x00, 0x02, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 ];
 
     #[test]
     fn size_export_directory_table() {
         assert_eq!(::std::mem::size_of::<ExportDirectoryTable>(), SIZEOF_EXPORT_DIRECTORY_TABLE);
+    }
+
+    #[test]
+    fn parse_export_table() {
+        let data_dirs = DataDirectories::parse(&CORKAMI_POCS_PE_EXPORTSDATA_EXE[..], 16, &mut 0xb8).unwrap();
+        let export_table = data_dirs.get_export_table().unwrap();
+
+        assert_eq!(export_table.virtual_address, 0x10b0);
+        assert_eq!(export_table.size, 0x0);
+    }
+
+    #[test]
+    fn parse_export_directory() {
+        let data_dir = ExportDirectoryTable::parse(&CORKAMI_POCS_PE_EXPORTSDATA_EXE[..], 0x2b0);
+        assert!(data_dir.is_ok());
+
+        let data_dir = data_dir.unwrap();
+        assert_eq!(data_dir.export_flags, 0x0);
+        assert_eq!(data_dir.time_date_stamp, 0x0);
+        assert_eq!(data_dir.major_version, 0x0);
+        assert_eq!(data_dir.minor_version, 0x0);
+        assert_eq!(data_dir.name_rva, 0x0);
+        assert_eq!(data_dir.ordinal_base, 0x0);
+        assert_eq!(data_dir.address_table_entries, 0x4);
+        assert_eq!(data_dir.number_of_name_pointers, 0x0);
+        assert_eq!(data_dir.export_address_table_rva, 0x10e0);
+        assert_eq!(data_dir.name_pointer_rva, 0x0);
+        assert_eq!(data_dir.ordinal_table_rva, 0x1100);
     }
 }

--- a/src/pe/header.rs
+++ b/src/pe/header.rs
@@ -18,8 +18,10 @@ pub const PE_POINTER_OFFSET: u32 = 0x3c;
 
 impl DosHeader {
     pub fn parse(bytes: &[u8]) -> error::Result<Self> {
-        let signature = bytes.pread_with(0, scroll::LE)?;
-        let pe_pointer = bytes.pread_with(PE_POINTER_OFFSET as usize, scroll::LE)?;
+        let signature = bytes.pread_with(0, scroll::LE)
+            .map_err(|_| error::Error::Malformed(format!("cannot parse DOS signature (offset {:#x})", 0)))?;
+        let pe_pointer = bytes.pread_with(PE_POINTER_OFFSET as usize, scroll::LE)
+            .map_err(|_| error::Error::Malformed(format!("cannot parse PE header pointer (offset {:#x})", PE_POINTER_OFFSET)))?;
         Ok (DosHeader { signature: signature, pe_pointer: pe_pointer })
     }
 }
@@ -49,14 +51,22 @@ pub const COFF_MACHINE_X86_64: u16 = 0x8664;
 impl CoffHeader {
     pub fn parse(bytes: &[u8], offset: &mut usize) -> error::Result<Self> {
         let mut coff = CoffHeader::default();
-        coff.signature = bytes.gread_with(offset, scroll::LE)?;
-        coff.machine = bytes.gread_with(offset, scroll::LE)?;
-        coff.number_of_sections = bytes.gread_with(offset, scroll::LE)?;
-        coff.time_date_stamp = bytes.gread_with(offset, scroll::LE)?;
-        coff.pointer_to_symbol_table = bytes.gread_with(offset, scroll::LE)?;
-        coff.number_of_symbol_table = bytes.gread_with(offset, scroll::LE)?;
-        coff.size_of_optional_header = bytes.gread_with(offset, scroll::LE)?;
-        coff.characteristics = bytes.gread_with(offset, scroll::LE)?;
+        coff.signature = bytes.gread_with(offset, scroll::LE)
+            .map_err(|_| error::Error::Malformed(format!("cannot parse COFF signature (offset {:#x})", offset)))?;
+        coff.machine = bytes.gread_with(offset, scroll::LE)
+            .map_err(|_| error::Error::Malformed(format!("cannot parse COFF machine (offset {:#x})", offset)))?;
+        coff.number_of_sections = bytes.gread_with(offset, scroll::LE)
+            .map_err(|_| error::Error::Malformed(format!("cannot parse COFF number of sections (offset {:#x})", offset)))?;
+        coff.time_date_stamp = bytes.gread_with(offset, scroll::LE)
+            .map_err(|_| error::Error::Malformed(format!("cannot parse COFF time date stamp (offset {:#x})", offset)))?;
+        coff.pointer_to_symbol_table = bytes.gread_with(offset, scroll::LE)
+            .map_err(|_| error::Error::Malformed(format!("cannot parse COFF pointer to symbol table (offset {:#x})", offset)))?;
+        coff.number_of_symbol_table = bytes.gread_with(offset, scroll::LE)
+            .map_err(|_| error::Error::Malformed(format!("cannot parse COFF number of symbol (offset {:#x})", offset)))?;
+        coff.size_of_optional_header = bytes.gread_with(offset, scroll::LE)
+            .map_err(|_| error::Error::Malformed(format!("cannot parse COFF size of optional header (offset {:#x})", offset)))?;
+        coff.characteristics = bytes.gread_with(offset, scroll::LE)
+            .map_err(|_| error::Error::Malformed(format!("cannot parse COFF characteristics (offset {:#x})", offset)))?;
         Ok(coff)
     }
 }

--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -42,7 +42,7 @@ pub struct PE<'a> {
     /// Data for any imported symbols, and from which `dll`, etc., in this binary
     pub import_data: Option<import::ImportData<'a>>,
     /// The list of exported symbols in this binary, contains synthetic information for easier analysis
-    pub exports: Option<Vec<export::Export<'a>>>,
+    pub exports: Vec<export::Export<'a>>,
     /// The list symbols imported by this binary from other `dll`s
     pub imports: Vec<import::Import<'a>>,
     /// The list of libraries which this binary imports symbols from
@@ -67,7 +67,7 @@ impl<'a> PE<'a> {
         let is_lib = characteristic::is_dll(header.coff_header.characteristics);
         let mut entry = 0;
         let mut image_base = 0;
-        let mut exports = None;
+        let mut exports = vec![];
         let mut export_data = None;
         let mut name = None;
         let mut imports = vec![];
@@ -83,7 +83,7 @@ impl<'a> PE<'a> {
             if let &Some(export_table) = optional_header.data_directories.get_export_table() {
                 if let Ok(ed) = export::ExportData::parse(bytes, &export_table, &sections) {
                     debug!("export data {:#?}", ed);
-                    exports = export::Export::parse(bytes, &ed, &sections).ok();
+                    exports = export::Export::parse(bytes, &ed, &sections)?;
                     name = ed.name;
                     debug!("name: {:#?}", name);
                     export_data = Some(ed);

--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -42,7 +42,7 @@ pub struct PE<'a> {
     /// Data for any imported symbols, and from which `dll`, etc., in this binary
     pub import_data: Option<import::ImportData<'a>>,
     /// The list of exported symbols in this binary, contains synthetic information for easier analysis
-    pub exports: Vec<export::Export<'a>>,
+    pub exports: Option<Vec<export::Export<'a>>>,
     /// The list symbols imported by this binary from other `dll`s
     pub imports: Vec<import::Import<'a>>,
     /// The list of libraries which this binary imports symbols from
@@ -67,7 +67,7 @@ impl<'a> PE<'a> {
         let is_lib = characteristic::is_dll(header.coff_header.characteristics);
         let mut entry = 0;
         let mut image_base = 0;
-        let mut exports = vec![];
+        let mut exports = None;
         let mut export_data = None;
         let mut name = None;
         let mut imports = vec![];
@@ -81,12 +81,13 @@ impl<'a> PE<'a> {
             is_64 = optional_header.container()? == container::Container::Big;
             debug!("entry {:#x} image_base {:#x} is_64: {}", entry, image_base, is_64);
             if let &Some(export_table) = optional_header.data_directories.get_export_table() {
-                let ed = export::ExportData::parse(bytes, &export_table, &sections)?;
-                debug!("export data {:#?}", ed);
-                exports = export::Export::parse(bytes, &ed, &sections)?;
-                name = Some(ed.name);
-                debug!("name: {}", ed.name);
-                export_data = Some(ed);
+                if let Ok(ed) = export::ExportData::parse(bytes, &export_table, &sections) {
+                    debug!("export data {:#?}", ed);
+                    exports = export::Export::parse(bytes, &ed, &sections).ok();
+                    name = ed.name;
+                    debug!("name: {:#?}", name);
+                    export_data = Some(ed);
+                }
             }
             debug!("exports: {:#?}", exports);
             if let &Some(import_table) = optional_header.data_directories.get_import_table() {


### PR DESCRIPTION
IMHO, goblin parser might be "too strict" in parsing export directory table and export entries of "abnormal" PEs. 

First, goblin will [refuse](https://github.com/m4b/goblin/blob/master/src/pe/export.rs#L77) parsing a PE if it cannot get the RVA of the name pointer table. In fact, an executable PE can have this RVA invalid, for example [this sample](https://github.com/corkami/pocs/blob/master/PE/bin/exportsdata.exe) from Corkami is a totally valid PE (it can even execute), but goblin will reject this PE.

Second, goblin parses export entries using [number of names](https://github.com/m4b/goblin/blob/master/src/pe/export.rs#L235) it found in the `export name pointer table` (and not from `number of names`), it will [stop parsing and reject](https://github.com/m4b/goblin/blob/master/src/pe/export.rs#L80) if there is a name with invalid RVA. But a `dll` can have invalid RVAs in the `export name pointer table`, in the following example of `wmi.dll` in Windows:

![wmi_dll](https://user-images.githubusercontent.com/79418/39410981-fccb8c38-4c00-11e8-9ff2-067af913bede.PNG)

I have modified the first entry (photo on the right), which contains RVA to the name of the first exported function `ControlTrace`, to zero; `Adlice PE viewer` still be able to list other entries (other tools like `FileAlyzer` and `PE Insider` are be able too). Moreover, the modified file can be loaded happily by `LoadLibraryEx` API (with `DONT_RESOLVE_DLL_REFERENCES` flag), and other entries can be found by `GetProcAddress` using the returned handle (of `LoadLibraryEx`)

This pull request try to fix these problems (and the problem I have reported in [issue 76](https://github.com/m4b/goblin/issues/76)). Of course YMMV, but please give me some ideas.