### PR TITLE
Update path to BTreeMap in alloc crate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.18.0
+  - 1.19.0
   - stable
   - beta
   - nightly

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ https://docs.rs/goblin/
 
 ### Usage
 
-Goblin requires `rustc` 1.18.
+Goblin requires `rustc` 1.19.
 
 Add to your `Cargo.toml`
 

--- a/src/archive/mod.rs
+++ b/src/archive/mod.rs
@@ -12,7 +12,7 @@ use strtab;
 use error::{Result, Error};
 
 use core::usize;
-use alloc::btree_map::BTreeMap;
+use alloc::collections::btree_map::BTreeMap;
 use alloc::vec::Vec;
 
 pub const SIZEOF_MAGIC: usize = 8;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ mod alloc {
     pub use std::boxed;
     pub use std::string;
     pub use std::vec;
-    pub use std::collections::btree_map;
+    pub use std::collections;
 }
 
 /////////////////////////


### PR DESCRIPTION
Also update required rustc to 1.19.

Fixes #94, cc @gz
