### PR TITLE
Get proper name for over-8-character sections

### DIFF
--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -59,8 +59,9 @@ impl<'a> PE<'a> {
         let offset = &mut (header.dos_header.pe_pointer as usize + header::SIZEOF_COFF_HEADER + header.coff_header.size_of_optional_header as usize);
         let nsections = header.coff_header.number_of_sections as usize;
         let mut sections = Vec::with_capacity(nsections);
+        let string_table_offset = header.coff_header.pointer_to_symbol_table + header.coff_header.number_of_symbol_table * 18;
         for i in 0..nsections {
-            let section = section_table::SectionTable::parse(bytes, offset)?;
+            let section = section_table::SectionTable::parse(bytes, offset, string_table_offset as usize)?;
             debug!("({}) {:#?}", i, section);
             sections.push(section);
         }

--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -18,6 +18,9 @@ mod utils;
 use error;
 use container;
 
+/// Size of a single symbol in the COFF Symbol Table.
+const COFF_SYMBOL_SIZE: u32 = 18;
+
 #[derive(Debug)]
 /// An analyzed PE32/PE32+ binary
 pub struct PE<'a> {
@@ -59,7 +62,8 @@ impl<'a> PE<'a> {
         let offset = &mut (header.dos_header.pe_pointer as usize + header::SIZEOF_COFF_HEADER + header.coff_header.size_of_optional_header as usize);
         let nsections = header.coff_header.number_of_sections as usize;
         let mut sections = Vec::with_capacity(nsections);
-        let string_table_offset = header.coff_header.pointer_to_symbol_table + header.coff_header.number_of_symbol_table * 18;
+        // Note that if we are handling a BigCoff, the size of the symbol will be different!
+        let string_table_offset = header.coff_header.pointer_to_symbol_table + header.coff_header.number_of_symbol_table * COFF_SYMBOL_SIZE;
         for i in 0..nsections {
             let section = section_table::SectionTable::parse(bytes, offset, string_table_offset as usize)?;
             debug!("({}) {:#?}", i, section);

--- a/src/pe/section_table.rs
+++ b/src/pe/section_table.rs
@@ -27,13 +27,18 @@ fn base64_decode_string_entry(s: &str) -> Result<usize, ()> {
 
     let mut val = 0;
     for c in s.bytes() {
-        let v = match c {
-            b'A'..=b'Z' => c - b'A' + 00, // 00..=25
-            b'a'..=b'z' => c - b'a' + 26, // 26..=51
-            b'0'..=b'9' => c - b'0' + 52, // 52..=61
-            b'+'        => 62,            // 62
-            b'/'        => 63,            // 63
-            _           => return Err(())
+        let v = if b'A' <= c && c <= b'Z' {
+            c - b'A' + 00 // 00..=25
+        } else if b'a' <= c && c <= b'z' {
+            c - b'a' + 26 // 26..=51
+        } else if b'0' <= c && c <= b'9' {
+            c - b'0' + 52 // 52..=61
+        } else if c == b'+' {
+            62            // 62
+        } else if c == b'/' {
+            63            // 63
+        } else {
+            return Err(())
         };
         val = val * 64 + v as usize;
     }


### PR DESCRIPTION
Fixes #99 

An early PR to get some reviews, as there are probably better ways to do this. I need to implement the base64 kind of section table names, and fix the error handling in some places.