### PR TITLE
Calculate number of read bytes for sections using file alignment

### DIFF
--- a/src/pe/debug.rs
+++ b/src/pe/debug.rs
@@ -12,8 +12,8 @@ pub struct DebugData<'a> {
 }
 
 impl<'a> DebugData<'a> {
-    pub fn parse(bytes: &'a [u8], dd: &data_directories::DataDirectory, sections: &[section_table::SectionTable]) -> error::Result<Self> {
-        let image_debug_directory = ImageDebugDirectory::parse(bytes, dd, sections)?;
+    pub fn parse(bytes: &'a [u8], dd: &data_directories::DataDirectory, sections: &[section_table::SectionTable], file_alignment: u32) -> error::Result<Self> {
+        let image_debug_directory = ImageDebugDirectory::parse(bytes, dd, sections, file_alignment)?;
         let codeview_pdb70_debug_info = CodeviewPDB70DebugInfo::parse(bytes, &image_debug_directory)?;
 
         Ok(DebugData{
@@ -54,9 +54,9 @@ pub const IMAGE_DEBUG_TYPE_FIXUP: u32 = 6;
 pub const IMAGE_DEBUG_TYPE_BORLAND: u32 = 9;
 
 impl ImageDebugDirectory {
-    fn parse(bytes: &[u8], dd: &data_directories::DataDirectory, sections: &[section_table::SectionTable]) -> error::Result<Self> {
+    fn parse(bytes: &[u8], dd: &data_directories::DataDirectory, sections: &[section_table::SectionTable], file_alignment: u32) -> error::Result<Self> {
         let rva = dd.virtual_address as usize;
-        let offset = utils::find_offset(rva, sections).ok_or(error::Error::Malformed(format!("Cannot map ImageDebugDirectory rva {:#x} into offset", rva)))?;;
+        let offset = utils::find_offset(rva, sections, file_alignment).ok_or(error::Error::Malformed(format!("Cannot map ImageDebugDirectory rva {:#x} into offset", rva)))?;;
         let idd: Self = bytes.pread_with(offset, scroll::LE)?;
         Ok (idd)
     }

--- a/src/pe/utils.rs
+++ b/src/pe/utils.rs
@@ -4,22 +4,54 @@ use error;
 
 use super::section_table;
 
+use std::cmp;
+
 pub fn is_in_range (rva: usize, r1: usize, r2: usize) -> bool {
     r1 <= rva && rva < r2
 }
 
+// reference: Peter Ferrie. Reliable algorithm to extract overlay of a PE. https://bit.ly/2vBX2bR
+#[inline]
+fn aligned_pointer_to_raw_data(pointer_to_raw_data: usize) -> usize {
+    const PHYSICAL_ALIGN: usize = 0x1ff;
+    pointer_to_raw_data & !PHYSICAL_ALIGN
+}
+
+#[inline]
+fn section_read_size(section: &section_table::SectionTable, file_alignment: u32) -> usize {
+    fn round_size(size: usize) -> usize {
+        const PAGE_MASK: usize = 0xfff;
+        (size + PAGE_MASK) & !PAGE_MASK
+    }
+
+    let file_alignment = file_alignment as usize;
+    let size_of_raw_data = section.size_of_raw_data as usize;
+    let virtual_size = section.virtual_size as usize;
+    let read_size = {
+        let read_size = (section.pointer_to_raw_data as usize + size_of_raw_data + file_alignment - 1) & !(file_alignment - 1);
+        cmp::min(read_size, round_size(size_of_raw_data))
+    };
+
+    if virtual_size == 0 {
+        read_size
+    } else {
+        cmp::min(read_size, round_size(virtual_size))
+    }
+}
+
 fn rva2offset (rva: usize, section: &section_table::SectionTable) -> usize {
-    (rva - section.virtual_address as usize) + section.pointer_to_raw_data as usize
+    (rva - section.virtual_address as usize) + aligned_pointer_to_raw_data(section.pointer_to_raw_data as usize)
 }
 
-fn is_in_section (rva: usize, section: &section_table::SectionTable) -> bool {
-    section.virtual_address as usize <= rva && rva < (section.virtual_address + section.virtual_size) as usize
+fn is_in_section (rva: usize, section: &section_table::SectionTable, file_alignment: u32) -> bool {
+    let section_rva = section.virtual_address as usize;
+    is_in_range(rva, section_rva, section_rva + section_read_size(section, file_alignment))
 }
 
-pub fn find_offset (rva: usize, sections: &[section_table::SectionTable]) -> Option<usize> {
+pub fn find_offset (rva: usize, sections: &[section_table::SectionTable], file_alignment: u32) -> Option<usize> {
     for (i, section) in sections.iter().enumerate() {
         debug!("Checking {} for {:#x} ∈ {:#x}..{:#x}", section.name().unwrap_or(""), rva, section.virtual_address, section.virtual_address + section.virtual_size);
-        if is_in_section(rva, &section) {
+        if is_in_section(rva, &section, file_alignment) {
             let offset = rva2offset(rva, &section);
             debug!("Found in section {}({}), remapped into offset {:#x}", section.name().unwrap_or(""), i, offset);
             return Some(offset)
@@ -28,12 +60,12 @@ pub fn find_offset (rva: usize, sections: &[section_table::SectionTable]) -> Opt
     None
 }
 
-pub fn find_offset_or (rva: usize, sections: &[section_table::SectionTable], msg: &str) -> error::Result<usize> {
-    find_offset(rva, sections).ok_or(error::Error::Malformed(msg.to_string()))
+pub fn find_offset_or (rva: usize, sections: &[section_table::SectionTable], file_alignment: u32, msg: &str) -> error::Result<usize> {
+    find_offset(rva, sections, file_alignment).ok_or(error::Error::Malformed(msg.to_string()))
 }
 
-pub fn try_name<'a>(bytes: &'a [u8], rva: usize, sections: &[section_table::SectionTable]) -> error::Result<&'a str> {
-    match find_offset(rva, sections) {
+pub fn try_name<'a>(bytes: &'a [u8], rva: usize, sections: &[section_table::SectionTable], file_alignment: u32) -> error::Result<&'a str> {
+    match find_offset(rva, sections, file_alignment) {
         Some(offset) => {
             Ok(bytes.pread::<&str>(offset)?)
         },


### PR DESCRIPTION
Hello all,

The  `pointer_to_raw_data` of each section should be [rounded down](https://reverseengineering.stackexchange.com/questions/4324/reliable-algorithm-to-extract-overlay-of-a-pe) to a multiple of 512. Moreover, the [valid address range](https://github.com/m4b/goblin/blob/master/src/pe/utils.rs#L15) of each section should be [calculated](https://reverseengineering.stackexchange.com/questions/4324/reliable-algorithm-to-extract-overlay-of-a-pe) using also `size_of_raw_data` and `file_alignment`, e.g. [quine.exe](https://github.com/corkami/pocs/blob/master/PE/bin/quine.exe) has `virtual_size` (of its unique section) is zero, but it is a valid PE.

To make the review becomes easier, I split the [previous PR](https://github.com/m4b/goblin/pull/98) (which is closed), into parts.

Many thanks for any comments.