### PR TITLE
Handle multiple LOAD program headers with different biases

### DIFF
--- a/src/pe/section_table.rs
+++ b/src/pe/section_table.rs
@@ -1,3 +1,4 @@
+use alloc::string::{String, ToString};
 use scroll::{self, Pread};
 use error::{self, Error};
 

--- a/src/pe/utils.rs
+++ b/src/pe/utils.rs
@@ -4,7 +4,7 @@ use error;
 
 use super::section_table;
 
-use std::cmp;
+use core::cmp;
 
 pub fn is_in_range (rva: usize, r1: usize, r2: usize) -> bool {
     r1 <= rva && rva < r2

--- a/tests/archive.rs
+++ b/tests/archive.rs
@@ -92,7 +92,6 @@ fn parse_self() {
     match goblin::Object::parse(&bytes).expect("parse object") {
         goblin::Object::Elf(elf) => {
             assert!(elf.entry == 0);
-            assert!(elf.bias == 0);
         }
         goblin::Object::Mach(goblin::mach::Mach::Binary(macho)) => {
             assert_eq!(macho.header.filetype, goblin::mach::header::MH_OBJECT);


### PR DESCRIPTION
Partial fix for #106 

Note that this changes `elf::dyn::DynamicInfo` so that it is no longer the same as `elf::dyn::dyn32::DynamicInfo`.