### PR TITLE
Update for breaking changes in scroll

### DIFF
--- a/examples/scroll.rs
+++ b/examples/scroll.rs
@@ -18,7 +18,7 @@ fn run () -> error::Result<()> {
     println!("header: {:?}", &header);
     // now lets write the header into some bytes
     let mut bytes = [0u8; elf64::header::SIZEOF_EHDR];
-    bytes.pwrite(header, 0)?;
+    bytes.pwrite(&header, 0)?;
     // read it back out
     let header2: elf64::header::Header = bytes.pread(0)?;
     // they're the same

--- a/src/elf/mod.rs
+++ b/src/elf/mod.rs
@@ -347,8 +347,7 @@ if_sylvan! {
 
     impl<'a> ctx::TryFromCtx<'a, (usize, Endian)> for Elf<'a> {
         type Error = ::error::Error;
-        type Size = usize;
-        fn try_from_ctx(src: &'a [u8], (_, _): (usize, Endian)) -> Result<(Elf<'a>, Self::Size), Self::Error> {
+        fn try_from_ctx(src: &'a [u8], (_, _): (usize, Endian)) -> Result<(Elf<'a>, usize), Self::Error> {
             let elf = Elf::parse(src)?;
             Ok((elf, src.len()))
         }

--- a/src/elf/note.rs
+++ b/src/elf/note.rs
@@ -166,8 +166,7 @@ if_alloc! {
 
     impl<'a> ctx::TryFromCtx<'a, (usize, container::Ctx)> for Note<'a> {
         type Error = error::Error;
-        type Size = usize;
-        fn try_from_ctx(bytes: &'a [u8], (alignment, ctx): (usize, container::Ctx)) -> Result<(Self, Self::Size), Self::Error> {
+        fn try_from_ctx(bytes: &'a [u8], (alignment, ctx): (usize, container::Ctx)) -> Result<(Self, usize), Self::Error> {
             let offset = &mut 0;
             let mut alignment = alignment;
             if alignment < 4 {

--- a/src/mach/load_command.rs
+++ b/src/mach/load_command.rs
@@ -496,8 +496,7 @@ impl ThreadCommand {
 
 impl<'a> ctx::TryFromCtx<'a, Endian> for ThreadCommand {
     type Error = ::error::Error;
-    type Size = usize;
-    fn try_from_ctx(bytes: &'a [u8], le: Endian) -> error::Result<(Self, Self::Size)> {
+    fn try_from_ctx(bytes: &'a [u8], le: Endian) -> error::Result<(Self, usize)> {
         use scroll::{Pread};
         let lc = bytes.pread_with::<LoadCommandHeader>(0, le)?;
 
@@ -1311,8 +1310,7 @@ pub enum CommandVariant {
 
 impl<'a> ctx::TryFromCtx<'a, Endian> for CommandVariant {
     type Error = ::error::Error;
-    type Size = usize;
-    fn try_from_ctx(bytes: &'a [u8], le: Endian) -> error::Result<(Self, Self::Size)> {
+    fn try_from_ctx(bytes: &'a [u8], le: Endian) -> error::Result<(Self, usize)> {
         use scroll::{Pread};
         use self::CommandVariant::*;
         let lc = bytes.pread_with::<LoadCommandHeader>(0, le)?;

--- a/src/pe/export.rs
+++ b/src/pe/export.rs
@@ -145,9 +145,8 @@ pub enum Reexport<'a> {
 
 impl<'a> scroll::ctx::TryFromCtx<'a, scroll::Endian> for Reexport<'a> {
     type Error = ::error::Error;
-    type Size = usize;
     #[inline]
-    fn try_from_ctx(bytes: &'a [u8], _ctx: scroll::Endian) -> Result<(Self, Self::Size), Self::Error> {
+    fn try_from_ctx(bytes: &'a [u8], _ctx: scroll::Endian) -> Result<(Self, usize), Self::Error> {
         use scroll::{Pread};
         let reexport = bytes.pread::<&str>(0)?;
         let reexport_len = reexport.len();
@@ -216,9 +215,8 @@ struct ExportCtx<'a> {
 
 impl<'a, 'b> scroll::ctx::TryFromCtx<'a, ExportCtx<'b>> for Export<'a> {
     type Error = error::Error;
-    type Size = usize;
     #[inline]
-    fn try_from_ctx(bytes: &'a [u8], ExportCtx { ptr, idx, sections, file_alignment, addresses, ordinals }: ExportCtx<'b>) -> Result<(Self, Self::Size), Self::Error> {
+    fn try_from_ctx(bytes: &'a [u8], ExportCtx { ptr, idx, sections, file_alignment, addresses, ordinals }: ExportCtx<'b>) -> Result<(Self, usize), Self::Error> {
         use self::ExportAddressTableEntry::*;
 
         let name = utils::find_offset(ptr as usize, sections, file_alignment).map_or(None, |offset| bytes.pread::<&str>(offset).ok());

--- a/src/pe/import.rs
+++ b/src/pe/import.rs
@@ -16,7 +16,7 @@ pub const IMPORT_BY_ORDINAL_64: u64 = 0x8000_0000_0000_0000;
 pub const IMPORT_RVA_MASK_32: u32 = 0x8fff_ffff;
 pub const IMPORT_RVA_MASK_64: u64 = 0x0000_0000_8fff_ffff;
 
-pub trait Bitfield<'a>: Into<u64> + PartialEq + Eq + LowerHex + Debug + TryFromCtx<'a, scroll::Endian, Error=scroll::Error, Size=usize> {
+pub trait Bitfield<'a>: Into<u64> + PartialEq + Eq + LowerHex + Debug + TryFromCtx<'a, scroll::Endian, Error=scroll::Error> {
     fn is_ordinal(&self) -> bool;
     fn to_ordinal(&self) -> u16;
     fn to_rva(&self) -> u32;

--- a/src/pe/optional_header.rs
+++ b/src/pe/optional_header.rs
@@ -262,8 +262,7 @@ impl OptionalHeader {
 
 impl<'a> ctx::TryFromCtx<'a, Endian> for OptionalHeader {
     type Error = ::error::Error;
-    type Size = usize;
-    fn try_from_ctx(bytes: &'a [u8], _: Endian) -> error::Result<(Self, Self::Size)> {
+    fn try_from_ctx(bytes: &'a [u8], _: Endian) -> error::Result<(Self, usize)> {
         let magic = bytes.pread_with::<u16>(0, LE)?;
         let offset = &mut 0;
         let (standard_fields, windows_fields): (StandardFields, WindowsFields) = match magic {


### PR DESCRIPTION
This PR updates `goblin` for the breaking changes in m4b/scroll#45 and m4b/scroll#47. It's mostly stripping out `Size`/`Units` and adding `&`.

There's a few places where `self` -> `&self` meant that `self.into()` became `&(*self.into())`. This change results in copying different structs – sometimes structs which could have been `#[derive(Copy)]` but weren't, so I added that where necessary.