### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+[attr]rust text eol=lf whitespace=tab-in-indent,trailing-space,tabwidth=4
+
+*.rs rust

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,1 @@
-[attr]rust text eol=lf whitespace=tab-in-indent,trailing-space,tabwidth=4
-
-*.rs rust
+*.rs linguist-language=rust


### PR DESCRIPTION
Fix wrong source analytics on GitHub: `*.rs` is called RenderScript
![image](https://user-images.githubusercontent.com/15225902/54071488-9d6e5e00-429f-11e9-8f52-39862077d5a0.png)

The solution is to [override the linguist](https://github.com/github/linguist#using-gitattributes).

**NOTE**: Please squash this PR before merging.