### PR TITLE
Adds the clone to strtab

### DIFF
--- a/src/strtab.rs
+++ b/src/strtab.rs
@@ -14,6 +14,7 @@ if_alloc! {
 /// A common string table format which is indexed by byte offsets (and not
 /// member index). Constructed using [`parse`](#method.parse)
 /// with your choice of delimiter. Please be careful.
+#[derive(Clone)]
 pub struct Strtab<'a> {
     bytes: &'a[u8],
     delim: ctx::StrCtx,


### PR DESCRIPTION
This is useful when borrowing the `elf::Elf` in a function that returns a non-borrowed value from it and, trying to return moved memory.

```rs
fn pair_section_names(bin: &goblin::elf::Elf ) -> Vec<(goblin::elf::SectionHeader, String)>{
    bin.section_headers.clone()
        .into_iter()
        .zip(
            bin.shdr_strtab.clone()
                .to_vec()
                .unwrap()
                .into_iter()
        )
        .map(|(s, tabname)| (s, tabname.to_string()))
        .collect::<Vec<(goblin::elf::SectionHeader, String)>>()
}
```