### PR TITLE
PE: check IAT for import entries if lookup table is null

### DIFF
--- a/src/pe/import.rs
+++ b/src/pe/import.rs
@@ -147,11 +147,17 @@ impl<'a> SyntheticImportDirectoryEntry<'a> {
         let name = utils::try_name(bytes, name_rva as usize, sections, file_alignment)?;
         let import_lookup_table = {
             let import_lookup_table_rva = import_directory_entry.import_lookup_table_rva;
-            debug!("Synthesizing lookup table imports for {} lib, with import lookup table rva: {:#x}", name, import_lookup_table_rva);
+            let import_address_table_rva = import_directory_entry.import_address_table_rva;
             if let Some(import_lookup_table_offset) = utils::find_offset(import_lookup_table_rva as usize, sections, file_alignment) {
+                debug!("Synthesizing lookup table imports for {} lib, with import lookup table rva: {:#x}", name, import_lookup_table_rva);
                 let import_lookup_table = SyntheticImportLookupTableEntry::parse::<T>(bytes, import_lookup_table_offset, sections, file_alignment)?;
-                debug!("Successfully synthesized import lookup table entry: {:#?}", import_lookup_table);
+                debug!("Successfully synthesized import lookup table entry from lookup table: {:#?}", import_lookup_table);
                 Some(import_lookup_table)
+            } else if let Some(import_address_table_offset) = utils::find_offset(import_address_table_rva as usize, sections, file_alignment) {
+                debug!("Synthesizing lookup table imports for {} lib, with import address table rva: {:#x}", name, import_lookup_table_rva);
+                let import_address_table  = SyntheticImportLookupTableEntry::parse::<T>(bytes, import_address_table_offset, sections, file_alignment)?;
+                debug!("Successfully synthesized import lookup table entry from IAT: {:#?}", import_address_table);
+                Some(import_address_table)
             } else {
                 None
             }


### PR DESCRIPTION
hi! In an interesting choice in the PE format, it's possible for an import thunk to have a null import lookup table, but still list imports. In that case, the loader can/will check the referenced IAT for RVAs of hints just as the lookup table would reference.

goblin doesn't know that, so PEs that have a null lookup table RVA in an import thunk just appear to have no imports. I don't have a particularly good test case to share, but RollerCoaster Tycoon Deluxe does this with its import thunks

from what I can tell, this change is correct, but I don't see any tests around PEs, so I just know RCT.EXE has imports now where it didn't before :D

edit: forgot the relevant bits of MSDN that I was going to include: the [Import Address Table](https://docs.microsoft.com/en-us/windows/desktop/Debug/pe-format#import-lookup-table) section mentions that lookup table and IAT have identical content, but I don't know anywhere linkable that mentions the loader-side detail that the lookup table may be null