### PR TITLE
Fix compliant after upgrading to Rust 2018 edition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ Before 1.0, this project does not adhere to [Semantic Versioning](http://semver.
 
 I'm sorry, I will try my best to ease breaking changes.  We're almost to 1.0, don't worry!
 
+## [Unreleased]
+### Added
+- Beautify debugging by using `debug_struct` in `Debug` implementation of many structs.
+
+### Changed
+- Bump lowest Rust version to 1.31.1 and transition project to Rust 2018 edition.
+- BREAKING: Rename module `goblin::elf::dyn` to `goblin::elf::dynamic` due to `dyn`
+  become a keyword in Rust 2018 edition.
+
+### Deprecated
+- `goblin::error::Error::description` would be deprecated. Use `to_string()` method instead.
+
+### Fixed
+- elf: handle some invalid sizes #121
+
 ## [0.0.21] - 2019-2-21
 ### Added
 - elf: add symbol visibility. thanks @pchickey: https://github.com/m4b/goblin/pull/119

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ I'm sorry, I will try my best to ease breaking changes.  We're almost to 1.0, do
 - BREAKING: Rename module `goblin::elf::dyn` to `goblin::elf::dynamic` due to `dyn`
   become a keyword in Rust 2018 edition.
 
-### Deprecated
-- `goblin::error::Error::description` would be deprecated. Use `to_string()` method instead.
+### Removed
+- `goblin::error::Error::description` would be removed. Use `to_string()` method instead.
 
 ### Fixed
 - elf: handle some invalid sizes #121

--- a/src/archive/mod.rs
+++ b/src/archive/mod.rs
@@ -71,7 +71,7 @@ impl MemberHeader {
         Ok(self.identifier.pread_with::<&str>(0, ::scroll::ctx::StrCtx::Length(SIZEOF_FILE_IDENTIFER))?)
     }
     pub fn size(&self) -> Result<usize> {
-        match usize::from_str_radix(self.file_size.pread_with::<&str>(0, ::scroll::ctx::StrCtx::Length(self.file_size.len()))?.trim_right(), 10) {
+        match usize::from_str_radix(self.file_size.pread_with::<&str>(0, ::scroll::ctx::StrCtx::Length(self.file_size.len()))?.trim_end(), 10) {
             Ok(file_size) => Ok(file_size),
             Err(err) => Err(Error::Malformed(format!("{:?} Bad file_size in header: {:?}", err, self)))
         }
@@ -117,7 +117,7 @@ impl<'a> Member<'a> {
             header.size -= len;
 
             // the name may have trailing NULs which we don't really want to keep
-            Some(name.trim_right_matches('\0'))
+            Some(name.trim_end_matches('\0'))
         } else {
             None
         };
@@ -142,7 +142,7 @@ impl<'a> Member<'a> {
         use core::str::FromStr;
 
         if name.len() > 3 && &name[0..3] == "#1/" {
-            let trimmed_name = &name[3..].trim_right_matches(' ');
+            let trimmed_name = &name[3..].trim_end_matches(' ');
             if let Ok(len) = usize::from_str(trimmed_name) {
                 Some(len)
             } else {
@@ -160,7 +160,7 @@ impl<'a> Member<'a> {
         } else if let Some(ref sysv_name) = self.sysv_name {
             sysv_name
         } else {
-            self.header.name.trim_right_matches(' ').trim_right_matches('/')
+            self.header.name.trim_end_matches(' ').trim_end_matches('/')
         }
     }
 
@@ -303,7 +303,7 @@ impl<'a> NameIndex<'a> {
     }
 
     pub fn get(&self, name: &str) -> Result<&'a str> {
-        let idx = name.trim_left_matches('/').trim_right();
+        let idx = name.trim_start_matches('/').trim_end();
         match usize::from_str_radix(idx, 10) {
             Ok(idx) => {
                 let name = match self.strtab.get(idx+1) {
@@ -312,7 +312,7 @@ impl<'a> NameIndex<'a> {
                 }?;
 
                 if name != "" {
-                    Ok(name.trim_right_matches('/'))
+                    Ok(name.trim_end_matches('/'))
                 }  else {
                     return Err(Error::Malformed(format!("Could not find {:?} in index", name).into()));
                 }

--- a/src/elf/compression_header.rs
+++ b/src/elf/compression_header.rs
@@ -162,6 +162,7 @@ pub mod compression_header64 {
 ///////////////////////////////
 
 if_alloc! {
+    #[cfg(feature = "endian_fd")]
     use crate::error;
     use core::fmt;
     use core::result;

--- a/src/elf/compression_header.rs
+++ b/src/elf/compression_header.rs
@@ -71,9 +71,9 @@ macro_rules! elf_compression_header_std_impl { ($size:ty) => {
             #[cfg(feature = "std")]
             pub fn from_fd(fd: &mut File, offset: u64) -> Result<CompressionHeader> {
                 let mut chdr = CompressionHeader::default();
-                r#try!(fd.seek(Start(offset)));
+                fd.seek(Start(offset))?;
                 unsafe {
-                    r#try!(fd.read(plain::as_mut_bytes(&mut chdr)));
+                    fd.read(plain::as_mut_bytes(&mut chdr))?;
                 }
                 Ok(chdr)
             }

--- a/src/elf/dyn.rs
+++ b/src/elf/dyn.rs
@@ -478,9 +478,9 @@ macro_rules! elf_dyn_std_impl {
                         let filesz = phdr.p_filesz as usize;
                         let dync = filesz / SIZEOF_DYN;
                         let mut dyns = vec![Dyn::default(); dync];
-                        r#try!(fd.seek(Start(phdr.p_offset as u64)));
+                        fd.seek(Start(phdr.p_offset as u64))?;
                         unsafe {
-                            r#try!(fd.read(plain::as_mut_bytes(&mut *dyns)));
+                            fd.read(plain::as_mut_bytes(&mut *dyns))?;
                         }
                         dyns.dedup();
                         return Ok(Some(dyns));

--- a/src/elf/mod.rs
+++ b/src/elf/mod.rs
@@ -49,7 +49,7 @@ pub mod section_header;
 pub mod compression_header;
 #[macro_use]
 pub mod sym;
-pub mod r#dyn;
+pub mod dynamic;
 #[macro_use]
 pub mod reloc;
 pub mod note;
@@ -74,8 +74,8 @@ if_sylvan! {
     pub type SectionHeader = section_header::SectionHeader;
     pub type Symtab<'a> = sym::Symtab<'a>;
     pub type Sym = sym::Sym;
-    pub type Dyn = r#dyn::Dyn;
-    pub type Dynamic = r#dyn::Dynamic;
+    pub type Dyn = dynamic::Dyn;
+    pub type Dynamic = dynamic::Dynamic;
     pub type Reloc = reloc::Reloc;
     pub type RelocSection<'a> = reloc::RelocSection<'a>;
 
@@ -281,7 +281,7 @@ if_sylvan! {
                 // parse the dynamic relocations
                 dynrelas = RelocSection::parse(bytes, dyn_info.rela, dyn_info.relasz, true, ctx)?;
                 dynrels = RelocSection::parse(bytes, dyn_info.rel, dyn_info.relsz, false, ctx)?;
-                let is_rela = dyn_info.pltrel as u64 == r#dyn::DT_RELA;
+                let is_rela = dyn_info.pltrel as u64 == dynamic::DT_RELA;
                 pltrelocs = RelocSection::parse(bytes, dyn_info.jmprel, dyn_info.pltrelsz, is_rela, ctx)?;
 
                 let mut num_syms = if let Some(gnu_hash) = dyn_info.gnu_hash {

--- a/src/elf/program_header.rs
+++ b/src/elf/program_header.rs
@@ -324,9 +324,9 @@ macro_rules! elf_program_header_std_impl { ($size:ty) => {
             #[cfg(feature = "std")]
             pub fn from_fd(fd: &mut File, offset: u64, count: usize) -> Result<Vec<ProgramHeader>> {
                 let mut phdrs = vec![ProgramHeader::default(); count];
-                r#try!(fd.seek(Start(offset)));
+                fd.seek(Start(offset))?;
                 unsafe {
-                    r#try!(fd.read(plain::as_mut_bytes(&mut *phdrs)));
+                    fd.read(plain::as_mut_bytes(&mut *phdrs))?;
                 }
                 Ok(phdrs)
             }

--- a/src/elf/section_header.rs
+++ b/src/elf/section_header.rs
@@ -325,9 +325,9 @@ macro_rules! elf_section_header_std_impl { ($size:ty) => {
             #[cfg(feature = "std")]
             pub fn from_fd(fd: &mut File, offset: u64, shnum: usize) -> Result<Vec<SectionHeader>> {
                 let mut shdrs = vec![SectionHeader::default(); shnum];
-                r#try!(fd.seek(Start(offset)));
+                fd.seek(Start(offset))?;
                 unsafe {
-                    r#try!(fd.read(plain::as_mut_bytes(&mut *shdrs)));
+                    fd.read(plain::as_mut_bytes(&mut *shdrs))?;
                 }
                 Ok(shdrs)
             }

--- a/src/elf/sym.rs
+++ b/src/elf/sym.rs
@@ -244,9 +244,9 @@ macro_rules! elf_sym_std_impl {
             pub fn from_fd(fd: &mut File, offset: usize, count: usize) -> Result<Vec<Sym>> {
                 // TODO: AFAIK this shouldn't work, since i pass in a byte size...
                 let mut syms = vec![Sym::default(); count];
-                r#try!(fd.seek(Start(offset as u64)));
+                fd.seek(Start(offset as u64))?;
                 unsafe {
-                    r#try!(fd.read(plain::as_mut_bytes(&mut *syms)));
+                    fd.read(plain::as_mut_bytes(&mut *syms))?;
                 }
                 syms.dedup();
                 Ok(syms)

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@
 
 use scroll;
 use core::result;
-use core::fmt::{self, Display};
+use core::fmt;
 use crate::alloc::string::String;
 #[cfg(feature = "std")]
 use std::{error, io};
@@ -23,28 +23,26 @@ pub enum Error {
 }
 
 impl Error {
+    #[deprecated(since = "0.0.22", note = "Please use the to_string() method instead")]
     pub fn description(&self) -> &str {
         match *self {
             #[cfg(feature = "std")]
-            Error::IO(_) => { "IO error" }
-            Error::Scroll(_) => { "Scroll error" }
-            Error::BadMagic(_) => { "Invalid magic number" }
-            Error::Malformed(_) => { "Entity is malformed in some way" }
+            Error::IO(_) => "IO error",
+            Error::Scroll(_) => "Scroll error",
+            Error::BadMagic(_) => "Invalid magic number",
+            Error::Malformed(_) => "Entity is malformed in some way",
         }
     }
 }
 
 #[cfg(feature = "std")]
 impl error::Error for Error {
-    fn description(&self) -> &str {
-        Error::description(self)
-    }
-    fn cause(&self) -> Option<&error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
-            Error::IO(ref io) => { io.cause() }
-            Error::Scroll(ref scroll) => { scroll.cause() }
-            Error::BadMagic(_) => { None }
-            Error::Malformed(_) => { None }
+            Error::IO(ref io) => io.source(),
+            Error::Scroll(ref scroll) => scroll.source(),
+            Error::BadMagic(_) => None,
+            Error::Malformed(_) => None,
         }
     }
 }
@@ -62,14 +60,14 @@ impl From<scroll::Error> for Error {
     }
 }
 
-impl Display for Error {
+impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             #[cfg(feature = "std")]
-            Error::IO(ref err) => { write!(fmt, "{}", err) },
-            Error::Scroll(ref err) => { write!(fmt, "{}", err) },
-            Error::BadMagic(magic) => { write! (fmt, "Invalid magic number: 0x{:x}", magic) },
-            Error::Malformed(ref msg) => { write! (fmt, "Malformed entity: {}", msg) },
+            Error::IO(ref err) => write!(fmt, "{}", err),
+            Error::Scroll(ref err) => write!(fmt, "{}", err),
+            Error::BadMagic(magic) => write!(fmt, "Invalid magic number: 0x{:x}", magic),
+            Error::Malformed(ref msg) => write!(fmt, "Malformed entity: {}", msg),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,8 +39,8 @@ impl Error {
 impl error::Error for Error {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
-            Error::IO(ref io) => io.source(),
-            Error::Scroll(ref scroll) => scroll.source(),
+            Error::IO(ref io) => Some(io),
+            Error::Scroll(ref scroll) => Some(scroll),
             Error::BadMagic(_) => None,
             Error::Malformed(_) => None,
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,19 +22,6 @@ pub enum Error {
     IO(io::Error),
 }
 
-impl Error {
-    #[deprecated(since = "0.0.22", note = "Please use the to_string() method instead")]
-    pub fn description(&self) -> &str {
-        match *self {
-            #[cfg(feature = "std")]
-            Error::IO(_) => "IO error",
-            Error::Scroll(_) => "Scroll error",
-            Error::BadMagic(_) => "Invalid magic number",
-            Error::Malformed(_) => "Entity is malformed in some way",
-        }
-    }
-}
-
 #[cfg(feature = "std")]
 impl error::Error for Error {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,7 +330,7 @@ pub mod elf32 {
     pub use crate::elf::header::header32 as header;
     pub use crate::elf::program_header::program_header32 as program_header;
     pub use crate::elf::section_header::section_header32 as section_header;
-    pub use crate::elf::r#dyn::dyn32 as r#dyn;
+    pub use crate::elf::dynamic::dyn32 as dynamic;
     pub use crate::elf::sym::sym32 as sym;
     pub use crate::elf::reloc::reloc32 as reloc;
     pub use crate::elf::note::Nhdr32 as Note;
@@ -346,7 +346,7 @@ pub mod elf64 {
     pub use crate::elf::header::header64 as header;
     pub use crate::elf::program_header::program_header64 as program_header;
     pub use crate::elf::section_header::section_header64 as section_header;
-    pub use crate::elf::r#dyn::dyn64 as r#dyn;
+    pub use crate::elf::dynamic::dyn64 as dynamic;
     pub use crate::elf::sym::sym64 as sym;
     pub use crate::elf::reloc::reloc64 as reloc;
     pub use crate::elf::note::Nhdr64 as Note;

--- a/src/mach/fat.rs
+++ b/src/mach/fat.rs
@@ -51,7 +51,7 @@ impl FatHeader {
     #[cfg(feature = "std")]
     pub fn from_fd(fd: &mut File) -> io::Result<FatHeader> {
         let mut header = [0; SIZEOF_FAT_HEADER];
-        r#try!(fd.read(&mut header));
+        fd.read(&mut header)?;
         Ok(FatHeader::from_bytes(&header))
     }
 


### PR DESCRIPTION
This PR:
- [x] Update CHANGELOG to reflect breaking changes.
- [x] Discuss about renaming module `elf::dyn` due to `dyn` become keyword in 
      Rust 2018 edition.
- [x] Use `?` to replace `try!` macro.
- [x] Fix deprecated warning on `trim_{left|right}[matches]` methods.
- [x] error: Remove `Error::description`.
