### PR TITLE
Enable deploying nightly doc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ os:
   - linux
   - osx
 matrix:
+  fast_finish: true
   allow_failures:
     - rust: nightly
 
@@ -18,3 +19,15 @@ script:
   - cargo test --release
   - make api
   - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then make nightly_api; fi
+before_deploy:
+  - cargo doc --no-deps
+  - echo '<meta http-equiv=refresh content=0;url=goblin/index.html>' > target/doc/index.html;
+deploy:
+  - provider: pages
+    skip-cleanup: true
+    local-dir: target/doc
+    github-token: "$GITHUB_OAUTH_TOKEN"
+    keep-history: false
+    on:
+      branch: master
+      condition: $TRAVIS_OS_NAME = "linux" && $TRAVIS_RUST_VERSION = "stable"


### PR DESCRIPTION
Closes #156 .

Note you need to set up [GitHub person access token](https://github.com/settings/tokens)
![image](https://user-images.githubusercontent.com/15225902/56601879-6e7d3300-6626-11e9-83b3-9a427ed3294e.png)
then save it in [Travis settings](https://travis-ci.org/m4b/goblin/settings) under the name `GITHUB_OAUTH_TOKEN`.