### PR TITLE
pe: add write support for COFF object files

### DIFF
--- a/src/pe/header.rs
+++ b/src/pe/header.rs
@@ -41,10 +41,10 @@ pub struct CoffHeader {
     pub characteristics: u16,
 }
 
-/// The size of `COFF_MAGIC` + `CoffHeader`.
-pub const SIZEOF_COFF_HEADER: usize = 24;
+pub const SIZEOF_COFF_HEADER: usize = 20;
 /// PE\0\0, little endian
-pub const COFF_MAGIC: u32 = 0x0000_4550;
+pub const PE_MAGIC: u32 = 0x0000_4550;
+pub const SIZEOF_PE_MAGIC: usize = 4;
 pub const COFF_MACHINE_X86: u16 = 0x14c;
 pub const COFF_MACHINE_X86_64: u16 = 0x8664;
 
@@ -124,7 +124,7 @@ impl Header {
 
 #[cfg(test)]
 mod tests {
-    use super::{DOS_MAGIC, COFF_MAGIC, COFF_MACHINE_X86, Header};
+    use super::{DOS_MAGIC, PE_MAGIC, COFF_MACHINE_X86, Header};
 
     const CRSS_HEADER: [u8; 688] =
         [0x4d, 0x5a, 0x90, 0x00, 0x03, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0xff, 0xff, 0x00, 0x00,
@@ -175,7 +175,7 @@ mod tests {
     fn crss_header () {
         let header = Header::parse(&&CRSS_HEADER[..]).unwrap();
         assert!(header.dos_header.signature == DOS_MAGIC);
-        assert!(header.signature == COFF_MAGIC);
+        assert!(header.signature == PE_MAGIC);
         assert!(header.coff_header.machine == COFF_MACHINE_X86);
         println!("header: {:?}", &header);
     }

--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -64,7 +64,7 @@ impl<'a> PE<'a> {
     pub fn parse(bytes: &'a [u8]) -> error::Result<Self> {
         let header = header::Header::parse(bytes)?;
         debug!("{:#?}", header);
-        let offset = &mut (header.dos_header.pe_pointer as usize + header::SIZEOF_COFF_HEADER + header.coff_header.size_of_optional_header as usize);
+        let offset = &mut (header.dos_header.pe_pointer as usize + header::SIZEOF_PE_MAGIC + header::SIZEOF_COFF_HEADER + header.coff_header.size_of_optional_header as usize);
         let sections = header.coff_header.sections(bytes, offset)?;
         let is_lib = characteristic::is_dll(header.coff_header.characteristics);
         let mut entry = 0;

--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -160,6 +160,8 @@ impl<'a> Coff<'a> {
         let offset = &mut 0;
         let header = header::CoffHeader::parse(bytes, offset)?;
         debug!("{:#?}", header);
+        // TODO: maybe parse optional header, but it isn't present for Windows.
+        *offset += header.size_of_optional_header as usize;
         let sections = header.sections(bytes, offset)?;
         let symbols = header.symbols(bytes)?;
         let strings = header.strings(bytes)?;

--- a/src/pe/relocation.rs
+++ b/src/pe/relocation.rs
@@ -1,5 +1,5 @@
 use crate::error;
-use scroll::{Pread, Pwrite};
+use scroll::{IOread, IOwrite, Pread, Pwrite, SizeWith};
 
 /// Size of a single COFF relocation.
 pub const COFF_RELOCATION_SIZE: usize = 10;
@@ -78,7 +78,7 @@ pub const IMAGE_REL_AMD64_SSPAN32: u16 = 0x0010;
 
 /// A COFF relocation.
 #[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Default, Pread, Pwrite)]
+#[derive(Debug, Copy, Clone, PartialEq, Default, Pread, Pwrite, IOread, IOwrite, SizeWith)]
 pub struct Relocation {
     /// The address of the item to which relocation is applied.
     ///

--- a/src/pe/symbol.rs
+++ b/src/pe/symbol.rs
@@ -1,7 +1,7 @@
 use crate::error;
 use crate::strtab;
 use core::fmt::{self, Debug};
-use scroll::{ctx, Pread, Pwrite};
+use scroll::{ctx, IOread, IOwrite, Pread, Pwrite, SizeWith};
 
 /// Size of a single symbol in the COFF Symbol Table.
 pub const COFF_SYMBOL_SIZE: usize = 18;
@@ -162,7 +162,7 @@ pub const IMAGE_SYM_CLASS_CLR_TOKEN: u8 = 107;
 ///
 /// [`ExceptionData::get_unwind_info`]: struct.ExceptionData.html#method.get_unwind_info
 #[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Default, Pread, Pwrite)]
+#[derive(Debug, Copy, Clone, PartialEq, Default, Pread, Pwrite, IOread, IOwrite, SizeWith)]
 pub struct Symbol {
     /// The name of the symbol.
     ///
@@ -238,6 +238,12 @@ impl Symbol {
         }
     }
 
+    /// Set the strtab offset of the symbol name.
+    pub fn set_name_offset(&mut self, offset: u32) {
+        self.name[..4].copy_from_slice(&[0; 4]);
+        self.name.pwrite_with(offset, 4, scroll::LE).unwrap();
+    }
+
     /// Return the base type of the symbol.
     ///
     /// This type uses the `IMAGE_SYM_TYPE_*` definitions.
@@ -285,7 +291,7 @@ impl Symbol {
 
 /// Auxiliary symbol record for function definitions.
 #[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Default, Pread, Pwrite)]
+#[derive(Debug, Copy, Clone, PartialEq, Default, Pread, Pwrite, IOread, IOwrite, SizeWith)]
 pub struct AuxFunctionDefinition {
     /// The symbol-table index of the corresponding `.bf` (begin function) symbol record.
     pub tag_index: u32,
@@ -307,7 +313,7 @@ pub struct AuxFunctionDefinition {
 
 /// Auxiliary symbol record for symbols with storage class `IMAGE_SYM_CLASS_FUNCTION`.
 #[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Default, Pread, Pwrite)]
+#[derive(Debug, Copy, Clone, PartialEq, Default, Pread, Pwrite, IOread, IOwrite, SizeWith)]
 pub struct AuxBeginAndEndFunction {
     /// Unused padding.
     pub unused1: [u8; 4],
@@ -336,7 +342,7 @@ pub const IMAGE_WEAK_EXTERN_SEARCH_ALIAS: u32 = 3;
 
 /// Auxiliary symbol record for weak external symbols.
 #[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Default, Pread, Pwrite)]
+#[derive(Debug, Copy, Clone, PartialEq, Default, Pread, Pwrite, IOread, IOwrite, SizeWith)]
 pub struct AuxWeakExternal {
     /// The symbol-table index of the symbol to be linked if an external definition is not found.
     pub tag_index: u32,
@@ -376,7 +382,7 @@ pub const IMAGE_COMDAT_SELECT_LARGEST: u8 = 6;
 
 /// Auxiliary symbol record for section definitions.
 #[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Default, Pread, Pwrite)]
+#[derive(Debug, Copy, Clone, PartialEq, Default, Pread, Pwrite, IOread, IOwrite, SizeWith)]
 pub struct AuxSectionDefinition {
     /// The size of section data; the same as `size_of_raw_data` in the section header.
     pub length: u32,

--- a/src/pe/symbol.rs
+++ b/src/pe/symbol.rs
@@ -16,6 +16,7 @@ pub const IMAGE_SYM_UNDEFINED: i16 = 0;
 pub const IMAGE_SYM_ABSOLUTE: i16 = -1;
 /// The symbol provides general type or debugging information but does not
 /// correspond to a section.
+pub const IMAGE_SYM_DEBUG: i16 = -2;
 
 // Base types for `Symbol::typ`.
 


### PR DESCRIPTION
See https://github.com/philipc/object-write/blob/master/src/coff.rs for an example of its usage.