### PR TITLE
Get build artifact path reliable with std::env::current_exe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,15 +2,15 @@
 name = "goblin"
 version = "0.1.3"
 authors = ["m4b <m4b.github.io@gmail.com>", "seu <seu@panopticon.re>", "Will Glynn <will@willglynn.com>", "Philip Craig <philipjcraig@gmail.com>"]
-edition = "2018"
-readme = "README.md"
-keywords = ["binary", "elf", "mach", "pe", "archive"]
-repository = "https://github.com/m4b/goblin"
-license = "MIT"
-description = "An impish, cross-platform, ELF, Mach-o, and PE binary parsing and loading crate"
-documentation = "https://docs.rs/goblin"
 categories = ["parsing", "development-tools::debugging"]
+documentation = "https://docs.rs/goblin"
+edition = "2018"
 include = ["src/**/*", "Cargo.toml", "CHANGELOG.md", "LICENSE", "README.md", "etc/*", "examples/*", "tests/*", "fuzz/**/*"]
+keywords = ["binary", "elf", "mach", "pe", "archive"]
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/m4b/goblin"
+description = "An impish, cross-platform, ELF, Mach-o, and PE binary parsing and loading crate"
 
 [dependencies]
 plain = "0.2.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,25 @@
 [package]
 name = "goblin"
 version = "0.1.3"
-authors = ["m4b <m4b.github.io@gmail.com>", "seu <seu@panopticon.re>", "Will Glynn <will@willglynn.com>", "Philip Craig <philipjcraig@gmail.com>"]
+authors = [
+    "m4b <m4b.github.io@gmail.com>",
+    "seu <seu@panopticon.re>",
+    "Will Glynn <will@willglynn.com>",
+    "Philip Craig <philipjcraig@gmail.com>",
+]
 categories = ["parsing", "development-tools::debugging"]
 documentation = "https://docs.rs/goblin"
 edition = "2018"
-include = ["src/**/*", "Cargo.toml", "CHANGELOG.md", "LICENSE", "README.md", "etc/*", "examples/*", "tests/*", "fuzz/**/*"]
+include = [
+    "/etc",
+    "/src",
+    "/tests",
+    "/build.rs",
+    "/CHANGELOG.md",
+    "/Cargo.toml",
+    "/LICENSE",
+    "/README.md",
+]
 keywords = ["binary", "elf", "mach", "pe", "archive"]
 license = "MIT"
 readme = "README.md"

--- a/examples/ar.rs
+++ b/examples/ar.rs
@@ -4,8 +4,7 @@ use goblin::elf;
 use goblin::archive;
 use std::env;
 use std::path::Path;
-use std::fs::File;
-use std::io::Read;
+use std::fs;
 
 pub fn main () {
     let len = env::args().len();
@@ -22,7 +21,7 @@ pub fn main () {
             }
         }
         let path = Path::new(&path);
-        let buffer = { let mut v = Vec::new(); let mut f = File::open(&path).unwrap(); f.read_to_end(&mut v).unwrap(); v};
+        let buffer = fs::read(path).unwrap();
         match archive::Archive::parse(&buffer) {
             Ok(archive) => {
                 println!("{:#?}", &archive);

--- a/examples/dyldinfo.rs
+++ b/examples/dyldinfo.rs
@@ -2,8 +2,7 @@ use goblin::mach;
 use std::env;
 use std::process;
 use std::path::Path;
-use std::fs::File;
-use std::io::Read;
+use std::fs;
 use std::borrow::Cow;
 
 fn usage() -> ! {
@@ -133,7 +132,7 @@ fn main () {
         // open the file
         let path = env::args_os().last().unwrap();
         let path = Path::new(&path);
-        let buffer = { let mut v = Vec::new(); let mut f = File::open(&path).unwrap(); f.read_to_end(&mut v).unwrap(); v};
+        let buffer = fs::read(&path).unwrap();
         match mach::MachO::parse(&buffer, 0) {
             Ok(macho) => {
                 // collect sections and sort by address

--- a/examples/lipo.rs
+++ b/examples/lipo.rs
@@ -2,8 +2,8 @@ use goblin::mach::{self, Mach};
 use std::env;
 use std::process;
 use std::path::Path;
-use std::fs::File;
-use std::io::{Read, Write};
+use std::fs::{self, File};
+use std::io::Write;
 
 fn usage() -> ! {
     println!("usage: lipo <options> <mach-o fat file>");
@@ -36,7 +36,7 @@ fn main () {
 
         let path_name = env::args_os().last().unwrap();
         let path = Path::new(&path_name);
-        let buffer = { let mut v = Vec::new(); let mut f = File::open(&path).unwrap(); f.read_to_end(&mut v).unwrap(); v};
+        let buffer = fs::read(path).unwrap();
         match mach::Mach::parse(&buffer) {
             Ok(Mach::Binary(_macho)) => {
                 println!("Already a single arch binary");

--- a/examples/rdr.rs
+++ b/examples/rdr.rs
@@ -1,15 +1,13 @@
 use goblin::error;
 use std::path::Path;
 use std::env;
-use std::fs::File;
-use std::io::Read;
+use std::fs;
 
 fn run () -> error::Result<()> {
     for (i, arg) in env::args().enumerate() {
         if i == 1 {
             let path = Path::new(arg.as_str());
-            let mut fd = File::open(path)?;
-            let buffer = { let mut v = Vec::new(); fd.read_to_end(&mut v).unwrap(); v};
+            let buffer = fs::read(path)?;
             let res = goblin::Object::parse(&buffer)?;
             println!("{:#?}", res);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,16 +28,13 @@
 //! use goblin::{error, Object};
 //! use std::path::Path;
 //! use std::env;
-//! use std::fs::File;
-//! use std::io::Read;
+//! use std::fs;
 //!
 //! fn run () -> error::Result<()> {
 //!     for (i, arg) in env::args().enumerate() {
 //!         if i == 1 {
 //!             let path = Path::new(arg.as_str());
-//!             let mut fd = File::open(path)?;
-//!             let mut buffer = Vec::new();
-//!             fd.read_to_end(&mut buffer)?;
+//!             let buffer = fs::read(path)?;
 //!             match Object::parse(&buffer)? {
 //!                 Object::Elf(elf) => {
 //!                     println!("elf: {:#?}", &elf);


### PR DESCRIPTION
We sort the `package` section based on https://github.com/rust-dev-tools/fmt-rfcs/blob/master/guide/cargo.md

@m4b Do we need to include `examples`, `tests` and `fuzz` directories
in goblin crate?
