### PR TITLE
Handle fileoff out of file boundary in load segment commandj when parsing Mach-O

### DIFF
--- a/src/mach/segment.rs
+++ b/src/mach/segment.rs
@@ -388,6 +388,16 @@ impl<'a> ctx::IntoCtx<container::Ctx> for Segment<'a> {
     }
 }
 
+/// Read data that belongs to a segment if the offset is within the boundaries of bytes.
+fn segment_data(bytes: &[u8], fileoff :u64, filesize :u64) -> Result<&[u8], error::Error> {
+    let data :&[u8] = if (fileoff as usize) < bytes.len() {
+        bytes.pread_with(fileoff as usize, filesize as usize)?
+    } else {
+        &[]
+    };
+    Ok(data)
+}
+
 impl<'a> Segment<'a> {
     /// Create a new, blank segment, with cmd either `LC_SEGMENT_64`, or `LC_SEGMENT`, depending on `ctx`.
     /// **NB** You are responsible for providing a correctly marshalled byte array as the sections. You should not use this for anything other than writing.
@@ -424,7 +434,6 @@ impl<'a> Segment<'a> {
     }
     /// Convert the raw C 32-bit segment command to a generalized version
     pub fn from_32(bytes: &'a[u8], segment: &SegmentCommand32, offset: usize, ctx: container::Ctx) -> Result<Self, error::Error> {
-        let data = bytes.pread_with(segment.fileoff as usize, segment.filesize as usize)?;
         Ok(Segment {
             cmd:      segment.cmd,
             cmdsize:  segment.cmdsize,
@@ -437,7 +446,7 @@ impl<'a> Segment<'a> {
             initprot: segment.initprot,
             nsects:   segment.nsects,
             flags:    segment.flags,
-            data,
+            data: segment_data(bytes, segment.fileoff as u64, segment.filesize as u64)?,
             offset,
             raw_data: bytes,
             ctx,
@@ -445,7 +454,6 @@ impl<'a> Segment<'a> {
     }
     /// Convert the raw C 64-bit segment command to a generalized version
     pub fn from_64(bytes: &'a [u8], segment: &SegmentCommand64, offset: usize, ctx: container::Ctx) -> Result<Self, error::Error> {
-        let data = bytes.pread_with(segment.fileoff as usize, segment.filesize as usize)?;
         Ok(Segment {
             cmd:      segment.cmd,
             cmdsize:  segment.cmdsize,
@@ -458,8 +466,8 @@ impl<'a> Segment<'a> {
             initprot: segment.initprot,
             nsects:   segment.nsects,
             flags:    segment.flags,
+            data: segment_data(bytes, segment.fileoff, segment.filesize)?,
             offset,
-            data,
             raw_data: bytes,
             ctx,
         })

--- a/src/mach/segment.rs
+++ b/src/mach/segment.rs
@@ -390,7 +390,7 @@ impl<'a> ctx::IntoCtx<container::Ctx> for Segment<'a> {
 
 /// Read data that belongs to a segment if the offset is within the boundaries of bytes.
 fn segment_data(bytes: &[u8], fileoff :u64, filesize :u64) -> Result<&[u8], error::Error> {
-    let data :&[u8] = if (fileoff as usize) < bytes.len() {
+    let data :&[u8] = if filesize != 0 {
         bytes.pread_with(fileoff as usize, filesize as usize)?
     } else {
         &[]


### PR DESCRIPTION
When parsing [BoringSSL](http://boringssl.googlesource.com/boringssl/)'s object files built on macOS I had goblin failing on some with `bad offset x` where x is outside of file boundary (pointing at the byte right after the end of the object). It _might_ be a toolchain bug but since such binaries exist it would be useful if goblin could handle them. objdump does not fail to parse those files nor Go's Mach-O parser does. The easiest way to reproduce the problem is to build BoringSSL and run bingrep on cpu-aarch64-fuchsia.c.o ([a copy in my Dropbox to save time](https://www.dropbox.com/s/rsvpwtqyikokn8b/cpu-aarch64-fuchsia.c.o?dl=1)) or fuchsia.c.o.

I've intentionally only checked `fileoff` being outside of file boundary and not `fileoff + filesize` to not hide problems when an object file is obviously malformed.