### PR TITLE
Fix parsing of Windows library archives

### DIFF
--- a/src/archive/mod.rs
+++ b/src/archive/mod.rs
@@ -295,13 +295,9 @@ impl<'a> Index<'a> {
             member_offsets.push(buffer.gread_with::<u32>(offset, scroll::LE)?);
         }
         let symbols = buffer.gread_with::<u32>(offset, scroll::LE)? as usize;
-        let mut symbol_indexes = Vec::with_capacity(symbols);
-        for _ in 0..symbols {
-            symbol_indexes.push(buffer.gread_with::<u16>(offset, scroll::LE)? as usize);
-        }
         let mut symbol_offsets = Vec::with_capacity(symbols);
-        for i in symbol_indexes {
-            symbol_offsets.push(member_offsets[i - 1]);
+        for _ in 0..symbols {
+            symbol_offsets.push(member_offsets[buffer.gread_with::<u16>(offset, scroll::LE)? as usize - 1]);
         }
         let strtab = strtab::Strtab::parse(buffer, *offset, buffer.len() - *offset, 0x0)?;
         Ok(Index {
@@ -404,7 +400,7 @@ impl<'a> Archive<'a> {
                 } else {
                     sysv_symbol_index_seen = true;
                     Index::parse_sysv_index(data)?
-                }
+                };
 
             } else if member.bsd_name == Some(BSD_SYMDEF_NAME) || member.bsd_name == Some(BSD_SYMDEF_SORTED_NAME) {
                 let data: &[u8] = buffer.pread_with(member.offset as usize, member.size())?;

--- a/src/archive/mod.rs
+++ b/src/archive/mod.rs
@@ -384,7 +384,7 @@ impl<'a> Archive<'a> {
         let mut index = Index::default();
         let mut sysv_name_index = NameIndex::default();
         let mut sysv_symbol_index_seen = false;
-        while *offset < buffer.len() {
+        while *offset + 1 < buffer.len() {
             // realign the cursor to a word boundary, if it's not on one already
             if *offset & 1 == 1 {
                 *offset += 1;


### PR DESCRIPTION
Implement parsing of Windows-specific Second Linker Member in SysV archives. Also fix the parser going out of boundaries if the archive is aligned.

I have verified that the parser succeeds on the samples from both #173 and #133. I was thinking about automated tests but it's quite ugly bringing binary data into the repository for testing. I think using cc crate to build binaries from source might be a better approach. With a Windows Travis pipeline the CI can verify parsing of PE binaries as well.