### PR TITLE
pe: only parse ExceptionData for machine X86_64

### DIFF
--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -116,9 +116,12 @@ impl<'a> PE<'a> {
                 debug_data = Some(debug::DebugData::parse(bytes, debug_table, &sections, file_alignment)?);
             }
 
-            debug!("exception data: {:#?}", exception_data);
-            if let Some(exception_table) = *optional_header.data_directories.get_exception_table() {
-                exception_data = Some(exception::ExceptionData::parse(bytes, exception_table, &sections, file_alignment)?);
+            if header.coff_header.machine == header::COFF_MACHINE_X86_64 {
+                // currently only x86_64 is supported
+                debug!("exception data: {:#?}", exception_data);
+                if let Some(exception_table) = *optional_header.data_directories.get_exception_table() {
+                    exception_data = Some(exception::ExceptionData::parse(bytes, exception_table, &sections, file_alignment)?);
+                }
             }
         }
         Ok( PE {


### PR DESCRIPTION
pe: Should parse .pdata on for machine X86_64 only. (what llvm does)
See detail from https://github.com/m4b/goblin/issues/179