### PR TITLE
[safety-dance] Remove some unsound or fragile usages of unsafe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ include = ["src/**/*", "Cargo.toml", "CHANGELOG.md", "LICENSE", "README.md", "et
 
 [dependencies]
 plain = "0.2.3"
+static_assertions = "0.3.4"
+zerocopy = "0.2.8"
 
 [dependencies.log]
 version = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,7 @@ include = ["src/**/*", "Cargo.toml", "CHANGELOG.md", "LICENSE", "README.md", "et
 
 [dependencies]
 plain = "0.2.3"
-static_assertions = "0.3.4"
-zerocopy = "0.2.8"
+macro_rules_attribute = "0.0.1"
 
 [dependencies.log]
 version = "0.4"

--- a/src/elf/compression_header.rs
+++ b/src/elf/compression_header.rs
@@ -1,3 +1,5 @@
+use crate::zerocopy;
+
 macro_rules! elf_compression_header {
     () => {
         impl ::core::fmt::Debug for CompressionHeader {
@@ -68,7 +70,7 @@ macro_rules! elf_compression_header_std_impl { ($size:ty) => {
             pub fn from_fd(fd: &mut File, offset: u64) -> Result<CompressionHeader> {
                 let mut chdr = CompressionHeader::default();
                 fd.seek(Start(offset))?;
-                fd.read_exact(::zerocopy::AsBytes::as_bytes_mut(&mut chdr))?;
+                fd.read_exact(zerocopy::AsBytes::as_bytes_mut(&mut chdr))?;
                 Ok(chdr)
             }
         }
@@ -80,9 +82,11 @@ use scroll::{Pread, Pwrite, SizeWith};
 
 pub mod compression_header32 {
     pub use crate::elf::compression_header::*;
+    use crate::zerocopy;
 
+    #[macro_rules_derive(AsBytesAndFromBytes!)]
     #[repr(C)]
-    #[derive(Copy, Clone, Eq, PartialEq, Default, AsBytes, FromBytes)]
+    #[derive(Copy, Clone, Eq, PartialEq, Default)]
     #[cfg_attr(feature = "alloc", derive(Pread, Pwrite, SizeWith))]
     /// The compression header is used at the start of SHF_COMPRESSED sections
     pub struct CompressionHeader {
@@ -122,8 +126,9 @@ pub mod compression_header32 {
 pub mod compression_header64 {
     pub use crate::elf::compression_header::*;
 
+    #[macro_rules_derive(AsBytesAndFromBytes!)]
     #[repr(C)]
-    #[derive(Copy, Clone, Eq, PartialEq, Default, AsBytes, FromBytes)]
+    #[derive(Copy, Clone, Eq, PartialEq, Default)]
     #[cfg_attr(feature = "alloc", derive(Pread, Pwrite, SizeWith))]
     /// The compression header is used at the start of SHF_COMPRESSED sections
     pub struct CompressionHeader {

--- a/src/elf/compression_header.rs
+++ b/src/elf/compression_header.rs
@@ -173,9 +173,7 @@ if_alloc! {
     use scroll::ctx;
     use crate::container::{Container, Ctx};
 
-    derive_unaligned_getters_for_packed_struct! {
-    #[repr(C, packed)]
-    #[derive(Default, PartialEq, Clone, Copy, AsBytes, FromBytes)]
+    #[derive(Default, PartialEq, Clone)]
     /// A unified CompressionHeader - convertable to and from 32-bit and 64-bit variants
     pub struct CompressionHeader {
         /// Compression format
@@ -184,7 +182,7 @@ if_alloc! {
         pub ch_size: u64,
         /// Uncompressed data alignment
         pub ch_addralign: u64,
-    }}
+    }
 
     impl CompressionHeader {
         /// Return the size of the underlying compression header, given a `container`
@@ -211,9 +209,9 @@ if_alloc! {
     impl fmt::Debug for CompressionHeader {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             f.debug_struct("CompressionHeader")
-                .field("ch_type", &self.ch_type())
-                .field("ch_size", &format_args!("0x{:x}", self.ch_size()))
-                .field("ch_addralign", &format_args!("0x{:x}", self.ch_addralign()))
+                .field("ch_type", &self.ch_type)
+                .field("ch_size", &format_args!("0x{:x}", self.ch_size))
+                .field("ch_addralign", &format_args!("0x{:x}", self.ch_addralign))
                 .finish()
         }
     }

--- a/src/elf/dynamic.rs
+++ b/src/elf/dynamic.rs
@@ -4,7 +4,7 @@ macro_rules! elf_dyn {
         #[cfg(feature = "alloc")]
         use scroll::{Pread, Pwrite, SizeWith};
         #[repr(C)]
-        #[derive(Copy, Clone, PartialEq, Default)]
+        #[derive(Copy, Clone, PartialEq, Default, AsBytes, FromBytes)]
         #[cfg_attr(feature = "alloc", derive(Pread, Pwrite, SizeWith))]
         /// An entry in the dynamic array
         pub struct Dyn {
@@ -480,9 +480,7 @@ macro_rules! elf_dyn_std_impl {
                         let dync = filesz / SIZEOF_DYN;
                         let mut dyns = vec![Dyn::default(); dync];
                         fd.seek(Start(u64::from(phdr.p_offset)))?;
-                        unsafe {
-                            fd.read_exact(plain::as_mut_bytes(&mut *dyns))?;
-                        }
+                        fd.read_exact(::zerocopy::AsBytes::as_bytes_mut(&mut *dyns))?;
                         dyns.dedup();
                         return Ok(Some(dyns));
                     }

--- a/src/elf/header.rs
+++ b/src/elf/header.rs
@@ -39,6 +39,10 @@ macro_rules! elf_header {
 
         use plain;
         // Declare that this is a plain type.
+        //
+        // # Safety
+        //
+        //   - `Header` is exclusively made of `Plain` types (integers)
         unsafe impl plain::Plain for Header {}
 
         impl Header {

--- a/src/elf/mod.rs
+++ b/src/elf/mod.rs
@@ -169,22 +169,22 @@ if_sylvan! {
         ) -> Option<note::NoteIterator<'a>> {
             let mut iters = vec![];
             for sect in &self.section_headers {
-                if sect.sh_type() != section_header::SHT_NOTE {
+                if sect.sh_type != section_header::SHT_NOTE {
                     continue;
                 }
 
                 if section_name.is_some() && !self.shdr_strtab
-                    .get(sect.sh_name())
+                    .get(sect.sh_name)
                     .map_or(false, |r| r.ok() == section_name) {
                     continue;
                 }
 
-                let offset = sect.sh_offset() as usize;
-                let alignment = sect.sh_addralign() as usize;
+                let offset = sect.sh_offset as usize;
+                let alignment = sect.sh_addralign as usize;
                 iters.push(note::NoteDataIterator {
                     data,
                     offset,
-                    size: offset + sect.sh_size() as usize,
+                    size: offset + sect.sh_size as usize,
                     ctx: (alignment, self.ctx)
                 });
             }
@@ -238,7 +238,7 @@ if_sylvan! {
                 } else {
                     let shdr = &section_headers[section_idx];
                     shdr.check_size(bytes.len())?;
-                    Strtab::parse(bytes, shdr.sh_offset() as usize, shdr.sh_size() as usize, 0x0)
+                    Strtab::parse(bytes, shdr.sh_offset as usize, shdr.sh_size as usize, 0x0)
                 }
             };
 
@@ -248,11 +248,11 @@ if_sylvan! {
             let mut syms = Symtab::default();
             let mut strtab = Strtab::default();
             for shdr in &section_headers {
-                if shdr.sh_type() as u32 == section_header::SHT_SYMTAB {
-                    let size = shdr.sh_entsize();
-                    let count = if size == 0 { 0 } else { shdr.sh_size() / size };
-                    syms = Symtab::parse(bytes, shdr.sh_offset() as usize, count as usize, ctx)?;
-                    strtab = get_strtab(&section_headers, shdr.sh_link() as usize)?;
+                if shdr.sh_type as u32 == section_header::SHT_SYMTAB {
+                    let size = shdr.sh_entsize;
+                    let count = if size == 0 { 0 } else { shdr.sh_size / size };
+                    syms = Symtab::parse(bytes, shdr.sh_offset as usize, count as usize, ctx)?;
+                    strtab = get_strtab(&section_headers, shdr.sh_link as usize)?;
                 }
             }
 
@@ -303,10 +303,10 @@ if_sylvan! {
 
             let mut shdr_relocs = vec![];
             for (idx, section) in section_headers.iter().enumerate() {
-                let is_rela = section.sh_type() == section_header::SHT_RELA;
-                if is_rela || section.sh_type() == section_header::SHT_REL {
+                let is_rela = section.sh_type == section_header::SHT_RELA;
+                if is_rela || section.sh_type == section_header::SHT_REL {
                     section.check_size(bytes.len())?;
-                    let sh_relocs = RelocSection::parse(bytes, section.sh_offset() as usize, section.sh_size() as usize, is_rela, ctx)?;
+                    let sh_relocs = RelocSection::parse(bytes, section.sh_offset as usize, section.sh_size as usize, is_rela, ctx)?;
                     shdr_relocs.push((idx, sh_relocs));
                 }
             }
@@ -410,7 +410,7 @@ mod tests {
                     if i == 11 {
                         let symtab = binary.strtab;
                         println!("sym: {:?}", &sym);
-                        assert_eq!(&symtab[sym.st_name()], "_start");
+                        assert_eq!(&symtab[sym.st_name], "_start");
                         break;
                     }
                 }
@@ -438,7 +438,7 @@ mod tests {
                     if i == 11 {
                         let symtab = binary.strtab;
                         println!("sym: {:?}", &sym);
-                        assert_eq!(&symtab[sym.st_name()], "__libc_csu_fini");
+                        assert_eq!(&symtab[sym.st_name], "__libc_csu_fini");
                         break;
                     }
                 }

--- a/src/elf/mod.rs
+++ b/src/elf/mod.rs
@@ -169,22 +169,22 @@ if_sylvan! {
         ) -> Option<note::NoteIterator<'a>> {
             let mut iters = vec![];
             for sect in &self.section_headers {
-                if sect.sh_type != section_header::SHT_NOTE {
+                if sect.sh_type() != section_header::SHT_NOTE {
                     continue;
                 }
 
                 if section_name.is_some() && !self.shdr_strtab
-                    .get(sect.sh_name)
+                    .get(sect.sh_name())
                     .map_or(false, |r| r.ok() == section_name) {
                     continue;
                 }
 
-                let offset = sect.sh_offset as usize;
-                let alignment = sect.sh_addralign as usize;
+                let offset = sect.sh_offset() as usize;
+                let alignment = sect.sh_addralign() as usize;
                 iters.push(note::NoteDataIterator {
                     data,
                     offset,
-                    size: offset + sect.sh_size as usize,
+                    size: offset + sect.sh_size() as usize,
                     ctx: (alignment, self.ctx)
                 });
             }
@@ -238,7 +238,7 @@ if_sylvan! {
                 } else {
                     let shdr = &section_headers[section_idx];
                     shdr.check_size(bytes.len())?;
-                    Strtab::parse(bytes, shdr.sh_offset as usize, shdr.sh_size as usize, 0x0)
+                    Strtab::parse(bytes, shdr.sh_offset() as usize, shdr.sh_size() as usize, 0x0)
                 }
             };
 
@@ -248,11 +248,11 @@ if_sylvan! {
             let mut syms = Symtab::default();
             let mut strtab = Strtab::default();
             for shdr in &section_headers {
-                if shdr.sh_type as u32 == section_header::SHT_SYMTAB {
-                    let size = shdr.sh_entsize;
-                    let count = if size == 0 { 0 } else { shdr.sh_size / size };
-                    syms = Symtab::parse(bytes, shdr.sh_offset as usize, count as usize, ctx)?;
-                    strtab = get_strtab(&section_headers, shdr.sh_link as usize)?;
+                if shdr.sh_type() as u32 == section_header::SHT_SYMTAB {
+                    let size = shdr.sh_entsize();
+                    let count = if size == 0 { 0 } else { shdr.sh_size() / size };
+                    syms = Symtab::parse(bytes, shdr.sh_offset() as usize, count as usize, ctx)?;
+                    strtab = get_strtab(&section_headers, shdr.sh_link() as usize)?;
                 }
             }
 
@@ -303,10 +303,10 @@ if_sylvan! {
 
             let mut shdr_relocs = vec![];
             for (idx, section) in section_headers.iter().enumerate() {
-                let is_rela = section.sh_type == section_header::SHT_RELA;
-                if is_rela || section.sh_type == section_header::SHT_REL {
+                let is_rela = section.sh_type() == section_header::SHT_RELA;
+                if is_rela || section.sh_type() == section_header::SHT_REL {
                     section.check_size(bytes.len())?;
-                    let sh_relocs = RelocSection::parse(bytes, section.sh_offset as usize, section.sh_size as usize, is_rela, ctx)?;
+                    let sh_relocs = RelocSection::parse(bytes, section.sh_offset() as usize, section.sh_size() as usize, is_rela, ctx)?;
                     shdr_relocs.push((idx, sh_relocs));
                 }
             }
@@ -410,7 +410,7 @@ mod tests {
                     if i == 11 {
                         let symtab = binary.strtab;
                         println!("sym: {:?}", &sym);
-                        assert_eq!(&symtab[sym.st_name], "_start");
+                        assert_eq!(&symtab[sym.st_name()], "_start");
                         break;
                     }
                 }
@@ -438,7 +438,7 @@ mod tests {
                     if i == 11 {
                         let symtab = binary.strtab;
                         println!("sym: {:?}", &sym);
-                        assert_eq!(&symtab[sym.st_name], "__libc_csu_fini");
+                        assert_eq!(&symtab[sym.st_name()], "__libc_csu_fini");
                         break;
                     }
                 }

--- a/src/elf/program_header.rs
+++ b/src/elf/program_header.rs
@@ -85,8 +85,7 @@ if_alloc! {
     use crate::container::{Ctx, Container};
     use crate::alloc::vec::Vec;
 
-    #[repr(C)]
-    #[derive(Default, PartialEq, Clone, AsBytes, FromBytes)]
+    #[derive(Default, PartialEq, Clone)]
     /// A unified ProgramHeader - convertable to and from 32-bit and 64-bit variants
     pub struct ProgramHeader {
         pub p_type  : u32,

--- a/src/elf/program_header.rs
+++ b/src/elf/program_header.rs
@@ -85,7 +85,8 @@ if_alloc! {
     use crate::container::{Ctx, Container};
     use crate::alloc::vec::Vec;
 
-    #[derive(Default, PartialEq, Clone)]
+    #[repr(C)]
+    #[derive(Default, PartialEq, Clone, AsBytes, FromBytes)]
     /// A unified ProgramHeader - convertable to and from 32-bit and 64-bit variants
     pub struct ProgramHeader {
         pub p_type  : u32,
@@ -327,9 +328,7 @@ macro_rules! elf_program_header_std_impl { ($size:ty) => {
             pub fn from_fd(fd: &mut File, offset: u64, count: usize) -> Result<Vec<ProgramHeader>> {
                 let mut phdrs = vec![ProgramHeader::default(); count];
                 fd.seek(Start(offset))?;
-                unsafe {
-                    fd.read_exact(plain::as_mut_bytes(&mut *phdrs))?;
-                }
+                fd.read_exact(::zerocopy::AsBytes::as_bytes_mut(&mut *phdrs))?;
                 Ok(phdrs)
             }
         }
@@ -343,7 +342,7 @@ pub mod program_header32 {
     pub use crate::elf::program_header::*;
 
     #[repr(C)]
-    #[derive(Copy, Clone, PartialEq, Default)]
+    #[derive(Copy, Clone, PartialEq, Default, AsBytes, FromBytes)]
     #[cfg_attr(feature = "alloc", derive(Pread, Pwrite, SizeWith))]
     /// A 64-bit ProgramHeader typically specifies how to map executable and data segments into memory
     pub struct ProgramHeader {
@@ -379,7 +378,7 @@ pub mod program_header64 {
     pub use crate::elf::program_header::*;
 
     #[repr(C)]
-    #[derive(Copy, Clone, PartialEq, Default)]
+    #[derive(Copy, Clone, PartialEq, Default, AsBytes, FromBytes)]
     #[cfg_attr(feature = "alloc", derive(Pread, Pwrite, SizeWith))]
     /// A 32-bit ProgramHeader typically specifies how to map executable and data segments into memory
     pub struct ProgramHeader {

--- a/src/elf/program_header.rs
+++ b/src/elf/program_header.rs
@@ -1,3 +1,4 @@
+use crate::zerocopy;
 /* Legal values for p_type (segment type).  */
 
 /// Program header table entry unused
@@ -327,7 +328,7 @@ macro_rules! elf_program_header_std_impl { ($size:ty) => {
             pub fn from_fd(fd: &mut File, offset: u64, count: usize) -> Result<Vec<ProgramHeader>> {
                 let mut phdrs = vec![ProgramHeader::default(); count];
                 fd.seek(Start(offset))?;
-                fd.read_exact(::zerocopy::AsBytes::as_bytes_mut(&mut *phdrs))?;
+                fd.read_exact(zerocopy::AsBytes::as_bytes_mut(&mut *phdrs))?;
                 Ok(phdrs)
             }
         }
@@ -340,8 +341,9 @@ use scroll::{Pread, Pwrite, SizeWith};
 pub mod program_header32 {
     pub use crate::elf::program_header::*;
 
+    #[macro_rules_derive(AsBytesAndFromBytes!)]
     #[repr(C)]
-    #[derive(Copy, Clone, PartialEq, Default, AsBytes, FromBytes)]
+    #[derive(Copy, Clone, PartialEq, Default)]
     #[cfg_attr(feature = "alloc", derive(Pread, Pwrite, SizeWith))]
     /// A 64-bit ProgramHeader typically specifies how to map executable and data segments into memory
     pub struct ProgramHeader {
@@ -367,6 +369,10 @@ pub mod program_header32 {
 
     use plain;
     // Declare that this is a plain type.
+    //
+    // # Safety
+    //
+    //   - `ProgramHeader` is exclusively made of `Plain` types (integers)
     unsafe impl plain::Plain for ProgramHeader {}
 
     elf_program_header_std_impl!(u32);
@@ -376,8 +382,9 @@ pub mod program_header32 {
 pub mod program_header64 {
     pub use crate::elf::program_header::*;
 
+    #[macro_rules_derive(AsBytesAndFromBytes!)]
     #[repr(C)]
-    #[derive(Copy, Clone, PartialEq, Default, AsBytes, FromBytes)]
+    #[derive(Copy, Clone, PartialEq, Default)]
     #[cfg_attr(feature = "alloc", derive(Pread, Pwrite, SizeWith))]
     /// A 32-bit ProgramHeader typically specifies how to map executable and data segments into memory
     pub struct ProgramHeader {
@@ -403,6 +410,10 @@ pub mod program_header64 {
 
     use plain;
     // Declare that this is a plain type.
+    //
+    // # Safety
+    //
+    //   - `ProgramHeader` is exclusively made of `Plain` types (integers)
     unsafe impl plain::Plain for ProgramHeader {}
 
     elf_program_header_std_impl!(u64);

--- a/src/elf/reloc.rs
+++ b/src/elf/reloc.rs
@@ -73,7 +73,7 @@ macro_rules! elf_reloc {
         #[cfg(feature = "alloc")]
         use scroll::{Pread, Pwrite, SizeWith};
         #[repr(C)]
-        #[derive(Clone, Copy, PartialEq, Default)]
+        #[derive(Clone, Copy, PartialEq, Default, AsBytes, FromBytes)]
         #[cfg_attr(feature = "alloc", derive(Pread, Pwrite, SizeWith))]
         /// Relocation with an explicit addend
         pub struct Rela {
@@ -209,9 +209,7 @@ macro_rules! elf_rela_std_impl { ($size:ident, $isize:ty) => {
                 let count = size / SIZEOF_RELA;
                 let mut relocs = vec![Rela::default(); count];
                 fd.seek(Start(offset as u64))?;
-                unsafe {
-                    fd.read_exact(plain::as_mut_bytes(&mut *relocs))?;
-                }
+                fd.read_exact(::zerocopy::AsBytes::as_bytes_mut(&mut *relocs))?;
                 Ok(relocs)
             }
         } // end if_alloc

--- a/src/elf/section_header.rs
+++ b/src/elf/section_header.rs
@@ -382,9 +382,7 @@ if_alloc! {
 
     #[cfg(feature = "endian_fd")]
     use crate::alloc::vec::Vec;
-    derive_unaligned_getters_for_packed_struct! {
-    #[repr(C, packed)]
-    #[derive(Default, PartialEq, Clone, Copy, AsBytes, FromBytes)]
+    #[derive(Default, PartialEq, Clone)]
     /// A unified SectionHeader - convertable to and from 32-bit and 64-bit variants
     pub struct SectionHeader {
         /// Section name (string tbl index)
@@ -407,7 +405,7 @@ if_alloc! {
         pub sh_addralign: u64,
         /// Entry size if section holds table
         pub sh_entsize: u64,
-    }}
+    }
 
     impl SectionHeader {
         /// Return the size of the underlying program header, given a `container`
@@ -462,7 +460,7 @@ if_alloc! {
             let (end, overflow) = self.sh_offset.overflowing_add(self.sh_size);
             if overflow || end > size as u64 {
                 let message = format!("Section {} size ({}) + offset ({}) is out of bounds. Overflowed: {}",
-                    self.sh_name(), self.sh_offset(), self.sh_size(), overflow);
+                    self.sh_name, self.sh_offset, self.sh_size, overflow);
                 return Err(error::Error::Malformed(message));
             }
             Ok(())
@@ -484,16 +482,16 @@ if_alloc! {
     impl fmt::Debug for SectionHeader {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             f.debug_struct("SectionHeader")
-                .field("sh_name", &self.sh_name())
-                .field("sh_type", &sht_to_str(self.sh_type()))
-                .field("sh_flags", &format_args!("0x{:x}", self.sh_flags()))
-                .field("sh_addr", &format_args!("0x{:x}", self.sh_addr()))
-                .field("sh_offset", &format_args!("0x{:x}", self.sh_offset()))
-                .field("sh_size", &format_args!("0x{:x}", self.sh_size()))
-                .field("sh_link", &format_args!("0x{:x}", self.sh_link()))
-                .field("sh_info", &format_args!("0x{:x}", self.sh_info()))
-                .field("sh_addralign", &format_args!("0x{:x}", self.sh_addralign()))
-                .field("sh_entsize", &format_args!("0x{:x}", self.sh_entsize()))
+                .field("sh_name", &self.sh_name)
+                .field("sh_type", &sht_to_str(self.sh_type))
+                .field("sh_flags", &format_args!("0x{:x}", self.sh_flags))
+                .field("sh_addr", &format_args!("0x{:x}", self.sh_addr))
+                .field("sh_offset", &format_args!("0x{:x}", self.sh_offset))
+                .field("sh_size", &format_args!("0x{:x}", self.sh_size))
+                .field("sh_link", &format_args!("0x{:x}", self.sh_link))
+                .field("sh_info", &format_args!("0x{:x}", self.sh_info))
+                .field("sh_addralign", &format_args!("0x{:x}", self.sh_addralign))
+                .field("sh_entsize", &format_args!("0x{:x}", self.sh_entsize))
                 .finish()
         }
     }

--- a/src/elf/sym.rs
+++ b/src/elf/sym.rs
@@ -327,9 +327,7 @@ if_alloc! {
     use crate::error::Result;
     use crate::alloc::vec::Vec;
 
-    derive_unaligned_getters_for_packed_struct! {
-    #[repr(C, packed)]
-    #[derive(Default, PartialEq, Clone, Copy, AsBytes, FromBytes)]
+    #[derive(Default, PartialEq, Clone)]
     /// A unified Sym definition - convertable to and from 32-bit and 64-bit variants
     pub struct Sym {
         pub st_name:     usize,
@@ -338,7 +336,7 @@ if_alloc! {
         pub st_shndx:    usize,
         pub st_value:    u64,
         pub st_size:     u64,
-    }}
+    }
 
     impl Sym {
         #[inline]
@@ -397,12 +395,12 @@ if_alloc! {
             let typ = self.st_type();
             let vis = self.st_visibility();
             f.debug_struct("Sym")
-                .field("st_name", &self.st_name())
-                .field("st_info", &format_args!("0x{:x} {} {}", self.st_info(), bind_to_str(bind), type_to_str(typ)))
-                .field("st_other", &format_args!("{} {}", self.st_other(), visibility_to_str(vis)))
-                .field("st_shndx", &self.st_shndx())
-                .field("st_value", &format_args!("0x{:x}", self.st_value()))
-                .field("st_size", &self.st_size())
+                .field("st_name", &self.st_name)
+                .field("st_info", &format_args!("0x{:x} {} {}", self.st_info, bind_to_str(bind), type_to_str(typ)))
+                .field("st_other", &format_args!("{} {}", self.st_other, visibility_to_str(vis)))
+                .field("st_shndx", &self.st_shndx)
+                .field("st_value", &format_args!("0x{:x}", self.st_value))
+                .field("st_size", &self.st_size)
                 .finish()
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,14 @@ extern crate core;
 #[macro_use]
 extern crate alloc;
 
+#[allow(unused_imports)]
+#[macro_use]
+extern crate static_assertions;
+
+#[allow(unused_imports)]
+#[macro_use]
+extern crate zerocopy;
+
 #[cfg(feature = "std")]
 mod alloc {
     pub use std::borrow;
@@ -116,6 +124,56 @@ macro_rules! if_alloc {
         $i
     )*)
 }
+
+#[allow(unused)]
+macro_rules! derive_unaligned_getters_for_packed_struct {(
+    #[repr(C, packed)]
+    $(#[$struct_meta:meta])*
+    $struct_pub:vis
+    struct $StructName:ident {
+        $(
+            $(#[$field_meta:meta])*
+            $field_pub:vis
+            $field_name:ident : $field_ty:ty
+        ),* $(,)?
+    }
+) => (
+    // define the struct, but where the fields are private
+    #[repr(C, packed)]
+    $(#[$struct_meta])*
+    $struct_pub
+    struct $StructName {
+        $(
+            $(#[$field_meta])*
+            $field_name : $field_ty,
+        )*
+    }
+
+    // add the (maybe) public unaligned getters
+    impl $StructName {
+        $(
+            #[inline]
+            $field_pub
+            fn $field_name (self: &'_ Self)
+                -> $field_ty
+            where
+                $field_ty : Copy,
+            {
+                unsafe {
+                    // # Safety
+                    //
+                    //   - $field_ty : Copy
+                    //
+                    //   - Based on the official documentation example: https://doc.rust-lang.org/std/ptr/fn.read_unaligned.html
+                    ::core::ptr::read_unaligned(
+                        &self.$field_name
+                            as *const $field_ty
+                    )
+                }
+            }
+        )*
+    }
+)}
 
 #[cfg(feature = "alloc")]
 pub mod error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,56 +125,6 @@ macro_rules! if_alloc {
     )*)
 }
 
-#[allow(unused)]
-macro_rules! derive_unaligned_getters_for_packed_struct {(
-    #[repr(C, packed)]
-    $(#[$struct_meta:meta])*
-    $struct_pub:vis
-    struct $StructName:ident {
-        $(
-            $(#[$field_meta:meta])*
-            $field_pub:vis
-            $field_name:ident : $field_ty:ty
-        ),* $(,)?
-    }
-) => (
-    // define the struct, but where the fields are private
-    #[repr(C, packed)]
-    $(#[$struct_meta])*
-    $struct_pub
-    struct $StructName {
-        $(
-            $(#[$field_meta])*
-            $field_name : $field_ty,
-        )*
-    }
-
-    // add the (maybe) public unaligned getters
-    impl $StructName {
-        $(
-            #[inline]
-            $field_pub
-            fn $field_name (self: &'_ Self)
-                -> $field_ty
-            where
-                $field_ty : Copy,
-            {
-                unsafe {
-                    // # Safety
-                    //
-                    //   - $field_ty : Copy
-                    //
-                    //   - Based on the official documentation example: https://doc.rust-lang.org/std/ptr/fn.read_unaligned.html
-                    ::core::ptr::read_unaligned(
-                        &self.$field_name
-                            as *const $field_ty
-                    )
-                }
-            }
-        )*
-    }
-)}
-
 #[cfg(feature = "alloc")]
 pub mod error;
 

--- a/src/mach/header.rs
+++ b/src/mach/header.rs
@@ -180,6 +180,9 @@ pub struct Header32 {
 
 pub const SIZEOF_HEADER_32: usize = 0x1c;
 
+// # Safety
+//
+//   - `Header32` is exclusively made of `Plain` types (integers)
 unsafe impl Plain for Header32 {}
 
 impl Header32 {
@@ -214,6 +217,9 @@ pub struct Header64 {
     pub reserved: u32,
 }
 
+// # Safety
+//
+//   - `Header64` is exclusively made of `Plain` types (integers)
 unsafe impl Plain for Header64 {}
 
 pub const SIZEOF_HEADER_64: usize = 32;

--- a/src/pe/data_directories.rs
+++ b/src/pe/data_directories.rs
@@ -24,6 +24,32 @@ pub struct DataDirectories {
     pub data_directories: [Option<DataDirectory>; NUM_DATA_DIRECTORIES],
 }
 
+macro_rules! make_DataDirectory_getters {(
+    $(
+        $name:ident => $idx:literal;
+    )*
+) => (
+    $(
+        #[inline]
+        pub
+        fn $name (self: &'_ Self)
+            -> &'_ Option<DataDirectory>
+        {
+            const INDEX: usize = $idx;
+            unsafe {
+                // # Safety
+                //
+                //   - Indexing is checked at compile-time
+                let _: [_; NUM_DATA_DIRECTORIES] =
+                    self.data_directories
+                ;
+                const_assert!(INDEX < NUM_DATA_DIRECTORIES);
+                self.data_directories.get_unchecked(INDEX)
+            }
+        }
+    )*
+)}
+
 impl DataDirectories {
     pub fn parse(bytes: &[u8], count: usize, offset: &mut usize) -> error::Result<Self> {
         let mut data_directories = [None; NUM_DATA_DIRECTORIES];
@@ -35,64 +61,21 @@ impl DataDirectories {
         }
         Ok (DataDirectories { data_directories })
     }
-    pub fn get_export_table(&self) -> &Option<DataDirectory> {
-        let idx = 0;
-        unsafe { self.data_directories.get_unchecked(idx) }
-    }
-    pub fn get_import_table(&self) -> &Option<DataDirectory> {
-        let idx = 1;
-        unsafe { self.data_directories.get_unchecked(idx) }
-    }
-    pub fn get_resource_table(&self) ->          &Option<DataDirectory> {
-        let idx = 2;
-        unsafe { self.data_directories.get_unchecked(idx) }
-    }
-    pub fn get_exception_table(&self) ->         &Option<DataDirectory> {
-        let idx = 3;
-        unsafe { self.data_directories.get_unchecked(idx) }
-    }
-    pub fn get_certificate_table(&self) ->       &Option<DataDirectory> {
-        let idx = 4;
-        unsafe { self.data_directories.get_unchecked(idx) }
-    }
-    pub fn get_base_relocation_table(&self) ->   &Option<DataDirectory> {
-        let idx = 5;
-        unsafe { self.data_directories.get_unchecked(idx) }
-    }
-    pub fn get_debug_table(&self) ->             &Option<DataDirectory> {
-        let idx = 6;
-        unsafe { self.data_directories.get_unchecked(idx) }
-    }
-    pub fn get_architecture(&self) ->            &Option<DataDirectory> {
-        let idx = 7;
-        unsafe { self.data_directories.get_unchecked(idx) }
-    }
-    pub fn get_global_ptr(&self) ->              &Option<DataDirectory> {
-        let idx = 8;
-        unsafe { self.data_directories.get_unchecked(idx) }
-    }
-    pub fn get_tls_table(&self) ->               &Option<DataDirectory> {
-        let idx = 9;
-        unsafe { self.data_directories.get_unchecked(idx) }
-    }
-    pub fn get_load_config_table(&self) ->       &Option<DataDirectory> {
-        let idx = 10;
-        unsafe { self.data_directories.get_unchecked(idx) }
-    }
-    pub fn get_bound_import_table(&self) ->      &Option<DataDirectory> {
-        let idx = 11;
-        unsafe { self.data_directories.get_unchecked(idx) }
-    }
-    pub fn get_import_address_table(&self) ->    &Option<DataDirectory> {
-        let idx = 12;
-        unsafe { self.data_directories.get_unchecked(idx) }
-    }
-    pub fn get_delay_import_descriptor(&self) -> &Option<DataDirectory> {
-        let idx = 13;
-        unsafe { self.data_directories.get_unchecked(idx) }
-    }
-    pub fn get_clr_runtime_header(&self) ->      &Option<DataDirectory> {
-        let idx = 14;
-        unsafe { self.data_directories.get_unchecked(idx) }
+    make_DataDirectory_getters! {
+        get_export_table            =>  0;
+        get_import_table            =>  1;
+        get_resource_table          =>  2;
+        get_exception_table         =>  3;
+        get_certificate_table       =>  4;
+        get_base_relocation_table   =>  5;
+        get_debug_table             =>  6;
+        get_architecture            =>  7;
+        get_global_ptr              =>  8;
+        get_tls_table               =>  9;
+        get_load_config_table       => 10;
+        get_bound_import_table      => 11;
+        get_import_address_table    => 12;
+        get_delay_import_descriptor => 13;
+        get_clr_runtime_header      => 14;
     }
 }

--- a/src/pe/data_directories.rs
+++ b/src/pe/data_directories.rs
@@ -43,7 +43,7 @@ macro_rules! make_DataDirectory_getters {(
                 let _: [_; NUM_DATA_DIRECTORIES] =
                     self.data_directories
                 ;
-                const_assert!(INDEX < NUM_DATA_DIRECTORIES);
+                const_assert!(NUM_DATA_DIRECTORIES > INDEX);
                 self.data_directories.get_unchecked(INDEX)
             }
         }

--- a/src/zerocopy.rs
+++ b/src/zerocopy.rs
@@ -1,0 +1,285 @@
+//! This module is heavily inspired by the `::zerocopy` crate,
+//! whose LICENSE states the following (BSD-3-Clause):
+/*!
+    Copyright 2019 The Fuchsia Authors. All rights reserved.
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+    * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following disclaimer
+    in the documentation and/or other materials provided with the
+    distribution.
+    * Neither the name of Google Inc. nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+//! The trick is that it does not use syn / quote, just plain old macro_rules!
+
+macro_rules! impl_macro {
+    (
+        unsafe
+        impl $Trait:path, for numeric_types!() $(;)?
+    ) => (
+        impl_macro!(@impl_for_all
+            unsafe
+            impl $Trait, for [
+                u8,     i8,
+                u16,    i16,
+                u32,    i32,
+                usize,  isize,
+                u64,    i64,
+                u128,   i128,
+            /* In practice these are not used */
+                // f32,
+                // f64,
+            ]
+        );
+    );
+
+    (
+        unsafe
+        impl $Trait:path, for composite_types!() $(;)?
+    ) => (
+        impl_macro!(@impl_for_all
+            unsafe
+            impl $Trait, for [
+                {T : $Trait} [T],
+            /* In practice these are not used */
+                // (),
+                // {
+                //     T1 : $Trait,
+                // } (T1,),
+                // {
+                //     T1 : $Trait,
+                //     T2 : $Trait,
+                // } (T1, T2,),
+                // {
+                //     T1 : $Trait,
+                //     T2 : $Trait,
+                //     T3 : $Trait,
+                // } (T1, T2, T3,),
+                // {
+                //     T1 : $Trait,
+                //     T2 : $Trait,
+                //     T3 : $Trait,
+                //     T4 : $Trait,
+                // } (T1, T2, T3, T4,),
+                // {T : ?Sized} ::core::marker::PhantomData<T>,
+            ]
+        );
+        impl_macro!(
+            unsafe
+            impl $Trait, for array_types!()
+        );
+    );
+
+    (
+        unsafe
+        impl $Trait:path, for array_types!() $(;)?
+    ) => (
+        impl_macro!(@impl_for_all
+            unsafe
+            impl $Trait, for [
+            /* In practice these are not used */
+                // {T : $Trait} [T;    0],
+                // {T : $Trait} [T;    1],
+                {T : $Trait} [T;    2],
+                {T : $Trait} [T;    3],
+                {T : $Trait} [T;    4],
+            /* In practice these are not used */
+                // {T : $Trait} [T;    5],
+                // {T : $Trait} [T;    6],
+                // {T : $Trait} [T;    7],
+                // {T : $Trait} [T;    8],
+                // {T : $Trait} [T;    9],
+                // {T : $Trait} [T;   10],
+                // {T : $Trait} [T;   11],
+                // {T : $Trait} [T;   12],
+                // {T : $Trait} [T;   13],
+                // {T : $Trait} [T;   14],
+                // {T : $Trait} [T;   15],
+                // {T : $Trait} [T;   16],
+                // {T : $Trait} [T;   17],
+                // {T : $Trait} [T;   18],
+                // {T : $Trait} [T;   19],
+                // {T : $Trait} [T;   20],
+                // {T : $Trait} [T;   21],
+                // {T : $Trait} [T;   22],
+                // {T : $Trait} [T;   23],
+                // {T : $Trait} [T;   24],
+                // {T : $Trait} [T;   25],
+                // {T : $Trait} [T;   26],
+                // {T : $Trait} [T;   27],
+                // {T : $Trait} [T;   28],
+                // {T : $Trait} [T;   29],
+                // {T : $Trait} [T;   30],
+                // {T : $Trait} [T;   31],
+                // {T : $Trait} [T;   32],
+                // {T : $Trait} [T;   64],
+                // {T : $Trait} [T;  128],
+                // {T : $Trait} [T;  256],
+                // {T : $Trait} [T;  512],
+                // {T : $Trait} [T; 1024],
+                // {T : $Trait} [T; 2048],
+                // {T : $Trait} [T; 4096],
+            ]
+        );
+    );
+
+    (@impl_for_all
+        unsafe
+        impl $Trait:path, for [
+            $(
+                $({$($generics:tt)*})? $T:ty
+            ),* $(,)?
+        ] $(;)?
+    ) => (
+        $(
+            impl_macro!(
+                unsafe
+                impl $Trait, for $({$($generics)*})? $T
+            );
+        )*
+    );
+
+    (
+        unsafe
+        impl $Trait:path, for $({$($generics:tt)*})? $T:ty $(;)?
+    ) => (
+        unsafe
+        impl $(<$($generics)*>)? $Trait for $T {}
+    );
+}
+
+/// Unsafe marker trait for types that are valid for any byte-pattern.
+///
+/// This is true of primitive types, and recursively for `#[repr(C)]`
+/// compositions of such types (such as arrays).
+///
+/// The derive macro takes care of deriving this trait with the necessary
+/// compile-time guards.
+pub(in crate)
+unsafe trait FromBytes {}
+
+/// Unsafe marker trait for types that are valid to cast as a slice of bytes.
+///
+/// This is true of primitive types, and recursively for `#[repr(C)]`
+/// compositions of such types, **as long as there is no padding** (such as
+/// arrays).
+///
+/// The derive macro takes care of deriving this trait with the necessary
+/// compile-time guards.
+pub(in crate)
+unsafe trait AsBytes {
+    fn as_bytes (self: &'_ Self)
+        -> &'_ [u8]
+    {
+        unsafe {
+            // # Safety
+            //
+            //   - contract of the trait
+            let num_bytes: usize = ::core::mem::size_of_val(self);
+            ::core::slice::from_raw_parts(
+                self
+                    as *const Self
+                    as *const u8
+                ,
+                num_bytes,
+            )
+        }
+    }
+
+    fn as_bytes_mut (self: &'_ mut Self)
+        -> &'_ mut [u8]
+    where
+        Self : FromBytes,
+    {
+        unsafe {
+            // # Safety
+            //
+            //   - contract of the trait (to view as a readable slice),
+            //
+            //   - `FromBytes` added bound makes mutation sound.
+            let num_bytes: usize = ::core::mem::size_of_val(self);
+            ::core::slice::from_raw_parts_mut(
+                self
+                    as *mut Self
+                    as *mut u8
+                ,
+                num_bytes,
+            )
+        }
+    }
+}
+
+impl_macro! {
+    unsafe
+    impl FromBytes, for numeric_types!()
+}
+impl_macro! {
+    unsafe
+    impl FromBytes, for composite_types!()
+}
+
+impl_macro! {
+    unsafe
+    impl AsBytes, for numeric_types!()
+}
+impl_macro! {
+    unsafe
+    impl AsBytes, for composite_types!()
+}
+
+macro_rules! AsBytesAndFromBytes {(
+    #[repr(C)]
+    $(#[$struct_meta:meta])*
+    $struct_vis:vis
+    struct $StructName:ident {
+        $(
+            $(#[$field_meta:meta])*
+            $field_vis:vis
+            $field_name:ident : $field_ty:ty
+        ),* $(,)?
+    }
+) => (
+    #[allow(bad_style, dead_code)]
+    const $StructName: () = {
+        $(
+            const_assert!(
+                $field_ty :
+                    $crate::zerocopy::AsBytes +
+                    $crate::zerocopy::FromBytes +
+                ,
+            );
+        )*
+        const_assert!(
+            ::core::mem::size_of::<$StructName>() ==
+            (0 $(+ ::core::mem::size_of::<$field_ty>())*)
+        );
+    };
+
+    // # Safety
+    //
+    //   - struct is `#[repr(C)]`,
+    //
+    //   - `const_assert!`ions check at compile-time that:
+    //
+    //       - there is no padding
+    //
+    //       - the inner types are both `AsBytes` and `FromBytes`
+    unsafe impl $crate::zerocopy::AsBytes for $StructName {}
+    unsafe impl $crate::zerocopy::FromBytes for $StructName {}
+)}


### PR DESCRIPTION
[![safety-dance](https://raw.githubusercontent.com/rust-secure-code/safety-dance/master/img/safety-dance.png)](https://github.com/rust-secure-code/safety-dance)

(This is currently a WIP PR, for other members of `safety-dance` to help audit and improve the code)

This PR aims to tackle the issues raised in https://github.com/rust-secure-code/safety-dance/issues/8 :

  - `unsafe { ... }` blocks and `unsafe impl`s had no

    ```rust
    // # Safety
    //
    //   - ...
    ```

    annotations, which makes it easy to forget or miss safety requirements / invariants to uphold, be it when the code is written, or later when the code is modified; it also makes quickly auditing the code harder. That's why, imho, it is very important to have such safety comment annotations;

  - The usages of `unsafe` corresponded to four cases:

      - `.get_unchecked` indexing for `pe/data_directories` array getters.

          - These have been factored in a macro to avoid code repetition, and within that macro compile-time assertions have been added so that the code is robust to changes;

      - `unsafe fn` exported to the API;

          - These have **not been audited** (yet): by virtue of being marked `unsafe`, users of the library must explicitely opt into calling these `unsafe` functions, and it is thus (mainly) their responsibility to do it correctly, hence making it a low-priority fix.

      - `unsafe impl` (for `::plain::Plain`).

          - These (implicitly) relied on each field also being `Plain`, such as integers, but where also used with a macro (_à la_ C++ template): hence a static assertion has been added in those cases to ensure that the "template" type parameter is indeed `Plain`.

          - `Plain` on its own offers non-`unsafe` transmute-based APIs to go into and from slices of bytes; the soundness responsibility of it falls down on the `::plain` crate and has **not been audited** either. Ideally, all the `::plain` usages could be replaced by `::zerocopy`, since thanks to the `#[derive(...)]` it offers compile-time checks for the soundness of these impls.

      - `unsafe { fd.read_exact(plain::as_mut_bytes(&mut /* some structure */)?); }`

          - These have been the main change of the PR: with the compile-time checked `#[derive(AsBytes)]`, we get access to a non-`unsafe` `::zerocopy::AsBytes::as_bytes_mut` for equivalent functionality.

          - This, in turn, has showed that there were some structures that did have padding, which has been removed with the `#[repr(C, packed)]` annotation, and the appropriate `ptr::read_unaligned`-based getters.