### PR TITLE
Fix errors, warnings and lints on Beta

### DIFF
--- a/src/elf/dynamic.rs
+++ b/src/elf/dynamic.rs
@@ -1,11 +1,14 @@
-
 macro_rules! elf_dyn {
     ($size:ty) => {
-        #[cfg(feature = "alloc")]
-        use scroll::{Pread, Pwrite, SizeWith};
+        // XXX: Do not import scroll traits here.
+        // See: https://github.com/rust-lang/rust/issues/65090#issuecomment-538668155
+
         #[repr(C)]
         #[derive(Copy, Clone, PartialEq, Default)]
-        #[cfg_attr(feature = "alloc", derive(Pread, Pwrite, SizeWith))]
+        #[cfg_attr(
+            feature = "alloc",
+            derive(scroll::Pread, scroll::Pwrite, scroll::SizeWith)
+        )]
         /// An entry in the dynamic array
         pub struct Dyn {
             /// Dynamic entry type
@@ -16,7 +19,7 @@ macro_rules! elf_dyn {
 
         use plain;
         unsafe impl plain::Plain for Dyn {}
-    }
+    };
 }
 
 // TODO: figure out what's the best, most friendly + safe API choice here - u32s or u64s

--- a/src/elf/gnu_hash.rs
+++ b/src/elf/gnu_hash.rs
@@ -31,11 +31,11 @@ mod tests {
     use super::hash;
     #[test]
     fn test_hash() {
-        assert_eq!(hash("")             , 0x00001505);
-        assert_eq!(hash("printf")       , 0x156b2bb8);
-        assert_eq!(hash("exit")         , 0x7c967e3f);
-        assert_eq!(hash("syscall")      , 0xbac212a0);
-        assert_eq!(hash("flapenguin.me"), 0x8ae9f18e);
+        assert_eq!(hash("")             , 0x0000_1505);
+        assert_eq!(hash("printf")       , 0x156b_2bb8);
+        assert_eq!(hash("exit")         , 0x7c96_7e3f);
+        assert_eq!(hash("syscall")      , 0xbac2_12a0);
+        assert_eq!(hash("flapenguin.me"), 0x8ae9_f18e);
     }
 }
 

--- a/src/elf/section_header.rs
+++ b/src/elf/section_header.rs
@@ -1,10 +1,14 @@
 macro_rules! elf_section_header {
     ($size:ident) => {
-        #[cfg(feature = "alloc")]
-        use scroll::{Pread, Pwrite, SizeWith};
+        // XXX: Do not import scroll traits here.
+        // See: https://github.com/rust-lang/rust/issues/65090#issuecomment-538668155
+
         #[repr(C)]
         #[derive(Copy, Clone, Eq, PartialEq, Default)]
-        #[cfg_attr(feature = "alloc", derive(Pread, Pwrite, SizeWith))]
+        #[cfg_attr(
+            feature = "alloc",
+            derive(scroll::Pread, scroll::Pwrite, scroll::SizeWith)
+        )]
         /// Section Headers are typically used by humans and static linkers for additional information or how to relocate the object
         ///
         /// **NOTE** section headers are strippable from a binary without any loss of portability/executability; _do not_ rely on them being there!
@@ -51,7 +55,7 @@ macro_rules! elf_section_header {
                     .finish()
             }
         }
-    }
+    };
 }
 
 /// Undefined section.

--- a/src/mach/segment.rs
+++ b/src/mach/segment.rs
@@ -446,7 +446,7 @@ impl<'a> Segment<'a> {
             initprot: segment.initprot,
             nsects:   segment.nsects,
             flags:    segment.flags,
-            data: segment_data(bytes, segment.fileoff as u64, segment.filesize as u64)?,
+            data: segment_data(bytes, u64::from(segment.fileoff), u64::from(segment.filesize))?,
             offset,
             raw_data: bytes,
             ctx,
@@ -512,7 +512,7 @@ impl<'a> Segments<'a> {
     }
     /// Get every section from every segment
     // thanks to SpaceManic for figuring out the 'b lifetimes here :)
-    pub fn sections<'b>(&'b self) -> Box<Iterator<Item=SectionIterator<'a>> + 'b> {
+    pub fn sections<'b>(&'b self) -> Box<dyn Iterator<Item=SectionIterator<'a>> + 'b> {
         Box::new(self.segments.iter().map(|segment| segment.into_iter()))
     }
 }

--- a/src/pe/debug.rs
+++ b/src/pe/debug.rs
@@ -56,7 +56,7 @@ pub const IMAGE_DEBUG_TYPE_BORLAND: u32 = 9;
 impl ImageDebugDirectory {
     fn parse(bytes: &[u8], dd: data_directories::DataDirectory, sections: &[section_table::SectionTable], file_alignment: u32) -> error::Result<Self> {
         let rva = dd.virtual_address as usize;
-        let offset = utils::find_offset(rva, sections, file_alignment).ok_or_else(|| error::Error::Malformed(format!("Cannot map ImageDebugDirectory rva {:#x} into offset", rva)))?;;
+        let offset = utils::find_offset(rva, sections, file_alignment).ok_or_else(|| error::Error::Malformed(format!("Cannot map ImageDebugDirectory rva {:#x} into offset", rva)))?;
         let idd: Self = bytes.pread_with(offset, scroll::LE)?;
         Ok (idd)
     }

--- a/src/pe/exception.rs
+++ b/src/pe/exception.rs
@@ -675,10 +675,10 @@ impl<'a> ExceptionData<'a> {
         let size = directory.size as usize;
 
         if size % RUNTIME_FUNCTION_SIZE != 0 {
-            Err(scroll::Error::BadInput {
+            return Err(error::Error::from(scroll::Error::BadInput {
                 size,
                 msg: "invalid exception directory table size",
-            })?;
+            }));
         }
 
         let rva = directory.virtual_address as usize;
@@ -687,7 +687,7 @@ impl<'a> ExceptionData<'a> {
         })?;
 
         if offset % 4 != 0 {
-            Err(scroll::Error::BadOffset(offset))?;
+            return Err(error::Error::from(scroll::Error::BadOffset(offset)));
         }
 
         Ok(ExceptionData {

--- a/src/pe/import.rs
+++ b/src/pe/import.rs
@@ -189,7 +189,7 @@ impl<'a> ImportData<'a> {
     pub fn parse<T: Bitfield<'a>>(bytes: &'a[u8], dd: data_directories::DataDirectory, sections: &[section_table::SectionTable], file_alignment: u32) -> error::Result<ImportData<'a>> {
         let import_directory_table_rva = dd.virtual_address as usize;
         debug!("import_directory_table_rva {:#x}", import_directory_table_rva);
-        let offset = &mut utils::find_offset(import_directory_table_rva, sections, file_alignment).ok_or_else(|| error::Error::Malformed(format!("Cannot create ImportData; cannot map import_directory_table_rva {:#x} into offset", import_directory_table_rva)))?;;
+        let offset = &mut utils::find_offset(import_directory_table_rva, sections, file_alignment).ok_or_else(|| error::Error::Malformed(format!("Cannot create ImportData; cannot map import_directory_table_rva {:#x} into offset", import_directory_table_rva)))?;
         debug!("import data offset {:#x}", offset);
         let mut import_data = Vec::new();
         loop {

--- a/src/pe/section_table.rs
+++ b/src/pe/section_table.rs
@@ -88,6 +88,7 @@ impl SectionTable {
         }
     }
 
+    #[allow(clippy::useless_let_if_seq)]
     pub fn set_name_offset(&mut self, mut idx: usize) -> error::Result<()> {
         if idx <= 9_999_999 { // 10^7 - 1
             // write!(&mut self.name[1..], "{}", idx) without using io::Write.


### PR DESCRIPTION
Taking a closer look at the test failures on beta it seems like `repr(C)` is broken now on Beta. The compiler introduces additional padding around `u32` fields that are already aligned. There were a bunch of other warnings that are now fixed in this PR, but the core problem still exists.