### PR TITLE
Elf: Ignore bad PT_INTERP rather than completely failing

### DIFF
--- a/src/elf/mod.rs
+++ b/src/elf/mod.rs
@@ -225,7 +225,7 @@ if_sylvan! {
                 if ph.p_type == program_header::PT_INTERP && ph.p_filesz != 0 {
                     let count = (ph.p_filesz - 1) as usize;
                     let offset = ph.p_offset as usize;
-                    interpreter = Some(bytes.pread_with::<&str>(offset, ::scroll::ctx::StrCtx::Length(count))?);
+                    interpreter = bytes.pread_with::<&str>(offset, ::scroll::ctx::StrCtx::Length(count)).ok();
                 }
             }
 


### PR DESCRIPTION
It seems some tools leave a PT_INTERP Phdr in a
bad way when manipulating the ELF file (for example,
https://bugzilla.redhat.com/show_bug.cgi?id=1770513 where splitting debug
info into a separate file leaves a bogus PT_INTERP header). When using
`gimli` with `object` to parse DWARF info, the PT_INTERP is irrelevent
so failing to load the file because of it causes loss of functionality.

This PR just ignores the PT_INTERP if it can't be
parsed/loaded/used. Another option would be to keep it as an
`Option<Result<_, _>>` so that any errors can be preserved but deferred
until someone tries to use the interp information.