### PR TITLE
Support ELF with empty PT_DYNAMIC reference

### DIFF
--- a/src/elf/dynamic.rs
+++ b/src/elf/dynamic.rs
@@ -372,10 +372,14 @@ if_alloc! {
                     let offset = phdr.p_offset as usize;
                     let filesz = phdr.p_filesz as usize;
                     // Ensure offset and filesz are valid.
-                    let bytes = bytes
-                        .pread_with::<&[u8]>(offset, filesz)
-                        .map_err(|_| crate::error::Error::Malformed(format!("Invalid PT_DYNAMIC size (offset {:#x}, filesz {:#x})",
-                                                               offset, filesz)))?;
+                    let bytes = if filesz > 0 {
+                        bytes
+                            .pread_with::<&[u8]>(offset, filesz)
+                            .map_err(|_| crate::error::Error::Malformed(format!("Invalid PT_DYNAMIC size (offset {:#x}, filesz {:#x})",
+                                                               offset, filesz)))?
+                    } else {
+                        &[]
+                    };
                     let size = Dyn::size_with(&ctx);
                     let count = filesz / size;
                     let mut dyns = Vec::with_capacity(count);


### PR DESCRIPTION
Some ELF files may contain `PT_DYNAMIC` program headers that have a zero `p_filesz` pointing to invalid memory if the corresponding section has been stripped. This currently causes an error when parsing the dynamic headers.


