### PR TITLE
Delete `feature(alloc)`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.31.1
+  - 1.36.0
   - stable
   - beta
   - nightly

--- a/Makefile
+++ b/Makefile
@@ -23,30 +23,28 @@ example:
 	cargo run --example=rdr -- /bin/ls
 
 api:
+	cargo build
 	cargo build --no-default-features
+	cargo build --no-default-features --features="alloc"
 	cargo build --no-default-features --features="std"
+	cargo build --no-default-features --features="endian_fd"
 	cargo build --no-default-features --features="endian_fd std"
 	cargo build --no-default-features --features="elf32"
 	cargo build --no-default-features --features="elf32 elf64"
 	cargo build --no-default-features --features="elf32 elf64 std"
+	cargo build --no-default-features --features="elf32 elf64 endian_fd"
 	cargo build --no-default-features --features="elf32 elf64 endian_fd std"
 	cargo build --no-default-features --features="archive std"
-	cargo build --no-default-features --features="mach64 std"
-	cargo build --no-default-features --features="mach32 std"
-	cargo build --no-default-features --features="mach64 mach32 std"
-	cargo build --no-default-features --features="pe32 std"
-	cargo build --no-default-features --features="pe32 pe64 std"
-	cargo build
-
-nightly_api:
-	cargo build --no-default-features --features="alloc"
-	cargo build --no-default-features --features="endian_fd"
-	cargo build --no-default-features --features="elf32 elf64 endian_fd"
-	cargo build --no-default-features --features="archive"
 	cargo build --no-default-features --features="mach64"
+	cargo build --no-default-features --features="mach64 std"
 	cargo build --no-default-features --features="mach32"
+	cargo build --no-default-features --features="mach32 std"
 	cargo build --no-default-features --features="mach64 mach32"
+	cargo build --no-default-features --features="mach64 mach32 std"
 	cargo build --no-default-features --features="pe32"
+	cargo build --no-default-features --features="pe32 std"
 	cargo build --no-default-features --features="pe32 pe64"
+	cargo build --no-default-features --features="pe32 pe64 std"
+	cargo build --no-default-features --features="archive"
 
 .PHONY: clean test example doc

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ https://docs.rs/goblin/
 
 ### Usage
 
-Goblin requires `rustc` 1.31.1.
+Goblin requires `rustc` 1.36.0.
 
 Add to your `Cargo.toml`
 

--- a/src/archive/mod.rs
+++ b/src/archive/mod.rs
@@ -12,8 +12,8 @@ use crate::strtab;
 use crate::error::{Result, Error};
 
 use core::usize;
-use crate::alloc::collections::btree_map::BTreeMap;
-use crate::alloc::vec::Vec;
+use alloc::collections::btree_map::BTreeMap;
+use alloc::vec::Vec;
 
 pub const SIZEOF_MAGIC: usize = 8;
 /// The magic number of a Unix Archive

--- a/src/elf/dynamic.rs
+++ b/src/elf/dynamic.rs
@@ -282,7 +282,7 @@ if_alloc! {
     use core::result;
     use crate::container::{Ctx, Container};
     use crate::strtab::Strtab;
-    use crate::alloc::vec::Vec;
+    use alloc::vec::Vec;
 
     #[derive(Default, PartialEq, Clone)]
     pub struct Dyn {
@@ -434,7 +434,7 @@ macro_rules! elf_dyn_std_impl {
         if_alloc! {
             use core::fmt;
             use core::slice;
-            use crate::alloc::vec::Vec;
+            use alloc::vec::Vec;
 
             use crate::elf::program_header::{PT_DYNAMIC};
             use crate::strtab::Strtab;

--- a/src/elf/header.rs
+++ b/src/elf/header.rs
@@ -156,7 +156,7 @@ if_alloc! {
     use scroll::{ctx, Endian};
     use core::fmt;
     use crate::container::{Ctx, Container};
-    use crate::alloc::string::ToString;
+    use alloc::string::ToString;
 
     #[derive(Copy, Clone, PartialEq)]
     /// An ELF header
@@ -520,7 +520,7 @@ macro_rules! elf_header_test {
             use crate::elf::header::Header as ElfHeader;
             use super::*;
             use crate::container::{Ctx, Container};
-            use crate::alloc::vec::Vec;
+            use alloc::vec::Vec;
             #[test]
             fn size_of() {
                 assert_eq!(::std::mem::size_of::<Header>(), SIZEOF_EHDR);

--- a/src/elf/mod.rs
+++ b/src/elf/mod.rs
@@ -66,7 +66,7 @@ if_sylvan! {
     use crate::strtab::Strtab;
     use crate::error;
     use crate::container::{Container, Ctx};
-    use crate::alloc::vec::Vec;
+    use alloc::vec::Vec;
     use core::cmp;
 
     pub type Header = header::Header;

--- a/src/elf/note.rs
+++ b/src/elf/note.rs
@@ -74,7 +74,7 @@ if_alloc! {
     use crate::error;
     use crate::container;
     use scroll::ctx;
-    use crate::alloc::vec::Vec;
+    use alloc::vec::Vec;
 
     /// An iterator over ELF binary notes in a note section or segment
     pub struct NoteDataIterator<'a> {

--- a/src/elf/program_header.rs
+++ b/src/elf/program_header.rs
@@ -83,7 +83,7 @@ if_alloc! {
     use core::result;
     use core::ops::Range;
     use crate::container::{Ctx, Container};
-    use crate::alloc::vec::Vec;
+    use alloc::vec::Vec;
 
     #[derive(Default, PartialEq, Clone)]
     /// A unified ProgramHeader - convertable to and from 32-bit and 64-bit variants

--- a/src/elf/reloc.rs
+++ b/src/elf/reloc.rs
@@ -283,7 +283,7 @@ if_alloc! {
     use core::result;
     use crate::container::{Ctx, Container};
     #[cfg(feature = "endian_fd")]
-    use crate::alloc::vec::Vec;
+    use alloc::vec::Vec;
 
     #[derive(Clone, Copy, PartialEq, Default)]
     /// A unified ELF relocation structure

--- a/src/elf/section_header.rs
+++ b/src/elf/section_header.rs
@@ -276,7 +276,7 @@ macro_rules! elf_section_header_std_impl { ($size:ty) => {
         use crate::elf::section_header::SectionHeader as ElfSectionHeader;
 
         use plain::Plain;
-        use crate::alloc::vec::Vec;
+        use alloc::vec::Vec;
 
         if_std! {
             use crate::error::Result;
@@ -377,7 +377,7 @@ if_alloc! {
     use crate::container::{Container, Ctx};
 
     #[cfg(feature = "endian_fd")]
-    use crate::alloc::vec::Vec;
+    use alloc::vec::Vec;
 
     #[derive(Default, PartialEq, Clone)]
     /// A unified SectionHeader - convertable to and from 32-bit and 64-bit variants

--- a/src/elf/sym.rs
+++ b/src/elf/sym.rs
@@ -327,7 +327,7 @@ if_alloc! {
     use core::result;
     use crate::container::{Ctx, Container};
     use crate::error::Result;
-    use crate::alloc::vec::Vec;
+    use alloc::vec::Vec;
 
     #[derive(Default, PartialEq, Clone)]
     /// A unified Sym definition - convertable to and from 32-bit and 64-bit variants

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@
 use scroll;
 use core::result;
 use core::fmt;
-use crate::alloc::string::String;
+use alloc::string::String;
 #[cfg(feature = "std")]
 use std::{error, io};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! * A PE32/PE32+ (64-bit) parser, and raw C structs
 //! * A Unix archive parser and loader
 //!
-//! Goblin requires at least `rustc` 1.31.1, uses the 2018 rust edition, and is developed on stable.
+//! Goblin requires at least `rustc` 1.36.0, uses the 2018 rust edition, and is developed on stable.
 //!
 //! Goblin primarily supports the following important use cases:
 //!
@@ -79,23 +79,13 @@
 //! via `endian_fd`
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(all(feature = "alloc", not(feature = "std")), feature(alloc))]
 
 #[cfg(feature = "std")]
 extern crate core;
 
-#[cfg(all(feature = "alloc", not(feature = "std")))]
+#[cfg(feature = "alloc")]
 #[macro_use]
 extern crate alloc;
-
-#[cfg(feature = "std")]
-mod alloc {
-    pub use std::borrow;
-    pub use std::boxed;
-    pub use std::string;
-    pub use std::vec;
-    pub use std::collections;
-}
 
 /////////////////////////
 // Misc/Helper Modules

--- a/src/mach/exports.rs
+++ b/src/mach/exports.rs
@@ -11,8 +11,8 @@ use scroll::{Pread, Uleb128};
 use crate::error;
 use core::fmt::{self, Debug};
 use crate::mach::load_command;
-use crate::alloc::vec::Vec;
-use crate::alloc::string::String;
+use alloc::vec::Vec;
+use alloc::string::String;
 
 type Flag = u64;
 

--- a/src/mach/imports.rs
+++ b/src/mach/imports.rs
@@ -7,7 +7,7 @@
 use core::ops::Range;
 use core::fmt::{self, Debug};
 use scroll::{Sleb128, Uleb128, Pread};
-use crate::alloc::vec::Vec;
+use alloc::vec::Vec;
 
 use crate::container;
 use crate::error;

--- a/src/mach/mod.rs
+++ b/src/mach/mod.rs
@@ -1,6 +1,6 @@
 //! The Mach-o, mostly zero-copy, binary format parser and raw struct definitions
 use core::fmt;
-use crate::alloc::vec::Vec;
+use alloc::vec::Vec;
 
 use log::debug;
 

--- a/src/mach/segment.rs
+++ b/src/mach/segment.rs
@@ -5,8 +5,8 @@ use log::{debug, warn};
 
 use core::fmt;
 use core::ops::{Deref, DerefMut};
-use crate::alloc::boxed::Box;
-use crate::alloc::vec::Vec;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 
 use crate::container;
 use crate::error;

--- a/src/pe/export.rs
+++ b/src/pe/export.rs
@@ -1,5 +1,5 @@
 use scroll::{Pread, Pwrite};
-use crate::alloc::vec::Vec;
+use alloc::vec::Vec;
 
 use log::debug;
 

--- a/src/pe/header.rs
+++ b/src/pe/header.rs
@@ -1,4 +1,4 @@
-use crate::alloc::vec::Vec;
+use alloc::vec::Vec;
 use crate::error;
 use crate::pe::{optional_header, section_table, symbol};
 use crate::strtab;

--- a/src/pe/import.rs
+++ b/src/pe/import.rs
@@ -1,5 +1,5 @@
-use crate::alloc::borrow::Cow;
-use crate::alloc::vec::Vec;
+use alloc::borrow::Cow;
+use alloc::vec::Vec;
 use core::fmt::{LowerHex, Debug};
 
 use scroll::{Pread, Pwrite, SizeWith};

--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -3,7 +3,7 @@
 
 // TODO: panics with unwrap on None for apisetschema.dll, fhuxgraphics.dll and some others
 
-use crate::alloc::vec::Vec;
+use alloc::vec::Vec;
 
 pub mod header;
 pub mod optional_header;

--- a/src/pe/section_table.rs
+++ b/src/pe/section_table.rs
@@ -1,4 +1,4 @@
-use crate::alloc::string::{String, ToString};
+use alloc::string::{String, ToString};
 use scroll::{ctx, Pread, Pwrite};
 use crate::error::{self, Error};
 use crate::pe::relocation;

--- a/src/pe/symbol.rs
+++ b/src/pe/symbol.rs
@@ -1,4 +1,4 @@
-use crate::alloc::vec::Vec;
+use alloc::vec::Vec;
 use crate::error;
 use crate::strtab;
 use core::fmt::{self, Debug};

--- a/src/pe/utils.rs
+++ b/src/pe/utils.rs
@@ -1,5 +1,5 @@
 use scroll::Pread;
-use crate::alloc::string::ToString;
+use alloc::string::ToString;
 use crate::error;
 
 use super::section_table;

--- a/src/strtab.rs
+++ b/src/strtab.rs
@@ -8,7 +8,7 @@ use core::fmt;
 use scroll::{ctx, Pread};
 if_alloc! {
     use crate::error;
-    use crate::alloc::vec::Vec;
+    use alloc::vec::Vec;
 }
 
 /// A common string table format which is indexed by byte offsets (and not


### PR DESCRIPTION
The feature `alloc` has been stable since 1.36.0.

The main change is in lib.rs, the rest is cleanup.