### PR TITLE
elf.dynamic: export ELF PIE flag

### DIFF
--- a/src/elf/dynamic.rs
+++ b/src/elf/dynamic.rs
@@ -275,6 +275,8 @@ pub const DF_1_SYMINTPOSE: u64 = 0x0080_0000;
 pub const DF_1_GLOBAUDIT: u64 = 0x0100_0000;
 /// Singleton dyn are used.
 pub const DF_1_SINGLETON: u64 = 0x0200_0000;
+/// Object is a Position Independent Executable (PIE).
+pub const DF_1_PIE: u64 = 0x0800_0000;
 
 if_alloc! {
     use core::fmt;


### PR DESCRIPTION
Defined here in binutils:
http://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=blob;f=include/elf/common.h;h=53b72445cafd079c16e7742ab4a72e6d2a2b68d3;hb=HEAD#l1092

`readelf` will report this flag:

```
$ ld -pie -o main main.o
[ .. ]
$ readelf -a main | grep PIE
 0x000000006ffffffb (FLAGS_1)            Flags: PIE
```

and so there's no reason why tricksy `goblin`s couldn't! :grinning: 