### PR TITLE
Protect against OOM when calling Vec::with_capacity

### DIFF
--- a/src/elf/mod.rs
+++ b/src/elf/mod.rs
@@ -122,6 +122,7 @@ if_sylvan! {
         pub interpreter: Option<&'a str>,
         /// A list of this binary's dynamic libraries it uses, if there are any
         pub libraries: Vec<&'a str>,
+        /// Whether this is a 64-bit elf or not
         pub is_64: bool,
         /// Whether this is a shared object or not
         pub is_lib: bool,

--- a/src/elf/section_header.rs
+++ b/src/elf/section_header.rs
@@ -455,7 +455,7 @@ if_alloc! {
             let mut section_headers = Vec::with_capacity(count);
             section_headers.push(empty_sh);
             for _ in 1..count {
-                let shdr  = bytes.gread_with(&mut offset, ctx)?;
+                let shdr = bytes.gread_with(&mut offset, ctx)?;
                 section_headers.push(shdr);
             }
             Ok(section_headers)

--- a/src/elf/section_header.rs
+++ b/src/elf/section_header.rs
@@ -446,10 +446,16 @@ if_alloc! {
                 // case the count is stored in the sh_size field of the null section header.
                 count = empty_sh.sh_size as usize;
             }
+
+            // Sanity check to avoid OOM
+            if count > bytes.len() / Self::size(ctx) {
+                let message = format!("Buffer is too short for {} section headers", count);
+                return Err(error::Error::Malformed(message));
+            }
             let mut section_headers = Vec::with_capacity(count);
             section_headers.push(empty_sh);
             for _ in 1..count {
-                let shdr = bytes.gread_with(&mut offset, ctx)?;
+                let shdr  = bytes.gread_with(&mut offset, ctx)?;
                 section_headers.push(shdr);
             }
             Ok(section_headers)


### PR DESCRIPTION
Malformed or malicious ELF files may trigger an OOM condition when pre-allocating vectors for program or section headers.

Prevent this by doing a quick and safe sanity check before doing the allocation.

This issue was found by fuzzing `goblin::elf::Elf::parse` using a valid ELF as a seed.