### PR TITLE
mach.constant: add more document for get_arch_name_from_types to avoid misuse

### DIFF
--- a/src/mach/constants.rs
+++ b/src/mach/constants.rs
@@ -367,10 +367,12 @@ pub mod cputype {
             /// use goblin::mach::constants::cputype::get_arch_name_from_types;
             /// use goblin::mach::Mach;
             ///
-            /// let buf = read("path/to/macho").unwrap();
-            /// if let Ok(Mach::Binary(a)) = Mach::parse(&buf) {
-            ///     println!("arch name: {}", get_arch_name_from_types(a.header.cputype(), a.header.cpusubtype()).unwrap());
-            /// }
+            /// read("path/to/macho").and_then(|buf| {
+            ///     if let Ok(Mach::Binary(a)) = Mach::parse(&buf) {
+            ///         println!("arch name: {}", get_arch_name_from_types(a.header.cputype(), a.header.cpusubtype()).unwrap());
+            ///     }
+            ///     Ok(())
+            /// });
             /// ```
             pub fn get_arch_name_from_types(cputype: CpuType, cpusubtype: CpuSubType)
                 -> Option<&'static str> {

--- a/src/mach/constants.rs
+++ b/src/mach/constants.rs
@@ -351,6 +351,23 @@ pub mod cputype {
             }
 
             /// Get the architecture name from cputype and cpusubtype
+            ///
+            /// When using this method to determine the architecture
+            /// name of an instance of
+            /// [`goblin::mach::header::Header`](/goblin/mach/header/struct.Header.html),
+            /// use the provided method
+            /// [`cputype()`](/goblin/mach/header/struct.Header.html#method.cputype) and
+            /// [`cpusubtype()`](/goblin/mach/header/struct.Header.html#method.cpusubtype)
+            /// instead of corresponding field `cputype` and `cpusubtype`.
+            ///
+            /// For example:
+            ///
+            /// ```rust
+            /// let buf = read("path/to/macho").unwrap();
+            /// if let Ok(Mach::Binary(a)) = Mach::parse(&buf) {
+            ///     println!("arch name: {}", get_arch_name_from_types(a.header.cputype(), a.header.cpusubtype()).unwrap());
+            /// }
+            /// ```
             pub fn get_arch_name_from_types(cputype: CpuType, cpusubtype: CpuSubType)
                 -> Option<&'static str> {
                 match (cputype, cpusubtype) {

--- a/src/mach/constants.rs
+++ b/src/mach/constants.rs
@@ -365,7 +365,7 @@ pub mod cputype {
             /// ```rust
             /// use std::fs::read;
             /// use goblin::mach::constants::cputype::get_arch_name_from_types;
-            /// use goblin::macho::Mach;
+            /// use goblin::mach::Mach;
             ///
             /// let buf = read("path/to/macho").unwrap();
             /// if let Ok(Mach::Binary(a)) = Mach::parse(&buf) {

--- a/src/mach/constants.rs
+++ b/src/mach/constants.rs
@@ -366,7 +366,7 @@ pub mod cputype {
             /// use std::fs::read;
             /// use goblin::mach::constants::cputype::get_arch_name_from_types;
             /// use goblin::macho::Mach;
-            /// 
+            ///
             /// let buf = read("path/to/macho").unwrap();
             /// if let Ok(Mach::Binary(a)) = Mach::parse(&buf) {
             ///     println!("arch name: {}", get_arch_name_from_types(a.header.cputype(), a.header.cpusubtype()).unwrap());

--- a/src/mach/constants.rs
+++ b/src/mach/constants.rs
@@ -363,6 +363,10 @@ pub mod cputype {
             /// For example:
             ///
             /// ```rust
+            /// use std::fs::read;
+            /// use goblin::mach::constants::cputype::get_arch_name_from_types;
+            /// use goblin::macho::Mach;
+            /// 
             /// let buf = read("path/to/macho").unwrap();
             /// if let Ok(Mach::Binary(a)) = Mach::parse(&buf) {
             ///     println!("arch name: {}", get_arch_name_from_types(a.header.cputype(), a.header.cpusubtype()).unwrap());


### PR DESCRIPTION
Related issue: #231 

# Problem

Some users may use `cputype` and `cpusubtype` directly to get architecture name, which may leads to wrong answer.

For example:

```rust
let buf = read("path/to/macho").unwrap();
if let Ok(Mach::Binary(a)) = Mach::parse(&buf) {
    println!("arch name: {}", get_arch_name_from_types(a.header.cputype, a.header.cpusubtype).unwrap());
}
```

When apply this to [arm64e](https://developer.apple.com/documentation/security/preparing_your_app_to_work_with_pointer_authentication) arch Mach-O file (which may be the main arch of iOS app and Apple Silicon Mac's app), the program crashes because the `get_arch_name_from_types` returns `None`.

# Reason

From Apple's open source [lipo](https://opensource.apple.com/source/cctools/cctools-949.0.1/misc/lipo.c.auto.html) code, we can find the code to display an executable's arch name is:

```c
case CPU_TYPE_ARM64:
    switch(cpusubtype & ~CPU_SUBTYPE_MASK){
        case CPU_SUBTYPE_ARM64_ALL:
            printf("arm64");
            break;
        case CPU_SUBTYPE_ARM64_V8:
            printf("arm64v8");
            break;
        case CPU_SUBTYPE_ARM64E:
            printf("arm64e");
            break;
        default:
            goto print_arch_unknown;
    }
    break;
```

(This branch is for CPU of type ARM64, for other CPU types, the code is similar)

It tests against the `cpusubtype & ~CPU_SUBTYPE_MASK` instead of `cpusubtype`.

And if we look at the code in [`src/mach/header.rs`](https://github.com/m4b/goblin/blob/master/src/mach/header.rs), we can find provided methods

```rust
impl Header {
    /// Returns the cpu type
    pub fn cputype(&self) -> CpuType {
        self.cputype
    }
    /// Returns the cpu subtype with the capabilities removed
    pub fn cpusubtype(&self) -> CpuSubType {
        self.cpusubtype & !CPU_SUBTYPE_MASK
    }
}
```

# Solution

As a result, we should use `cputype()` and `cpusubtype()` method instead of `cputype` and `cpusubtype` field to pass to `get_arch_name_from_types` method to  get the right architecture name. So I add some documentation for this method.