### PR TITLE
lib.parse: use TryInto trait to replace peek to make parse not need std

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,6 +280,7 @@ if_everything! {
     }
 
     /// Takes a reference to the first 16 bytes of the total bytes slice and convert it to an array for `peek_bytes` to use.
+    /// Returns None if bytes's length is less than 16.
     fn take_hint_bytes(bytes: &[u8]) -> Option<&[u8; 16]> {
         use core::convert::TryInto;
         bytes.get(0..16)


### PR DESCRIPTION
This PR is to avoid std for the `parse` method of `Object`.

The reason that `parse` need std is `peek` needs it, and `peek`'s task is:

1. take the first 16 bytes of the total bytes;
2. pass the taken array of 16 bytes to `peek_bytes` method.

And there is a no-std way to take the first 16 bytes of the total bytes:

```rust
fn take_hint_bytes(bytes: &[u8]) -> Option<&[u8; 16]> {
    use core::convert::TryInto;
    bytes.get(0..16)
        .and_then(|hint_bytes_slice| {
            hint_bytes_slice.try_into().ok()
        })
}
```

The core magic is [`get`](https://doc.rust-lang.org/std/primitive.slice.html#method.get) (which takes the first 16 elements of the given slice and returns a slice) and the `TryInto` trait (which converts the slice to array type, see more in [How to get a slice as an array in Rust?](https://stackoverflow.com/questions/25428920/)).

For compatibility reason, I don't delete `peek` method although it is dead code.