### PR TITLE
pe: add basic validations

### DIFF
--- a/src/pe/characteristic.rs
+++ b/src/pe/characteristic.rs
@@ -73,6 +73,7 @@ let show_type characteristics =
   else "MANY"                   (* print all *)
  */
 use crate::error;
+use alloc::borrow::ToOwned;
 
 pub const IMAGE_FILE_RELOCS_STRIPPED: u16 = 0x0001;
 pub const IMAGE_FILE_EXECUTABLE_IMAGE: u16 = 0x0002;

--- a/src/pe/characteristic.rs
+++ b/src/pe/characteristic.rs
@@ -72,6 +72,7 @@ let show_type characteristics =
   else if (has IMAGE_FILE_EXECUTABLE_IMAGE characteristics) then "EXE"
   else "MANY"                   (* print all *)
  */
+use crate::error;
 
 pub const IMAGE_FILE_RELOCS_STRIPPED: u16 = 0x0001;
 pub const IMAGE_FILE_EXECUTABLE_IMAGE: u16 = 0x0002;
@@ -90,10 +91,55 @@ pub const IMAGE_FILE_DLL: u16 = 0x2000;
 pub const IMAGE_FILE_UP_SYSTEM_ONLY: u16 = 0x4000;
 pub const IMAGE_FILE_BYTES_REVERSED_HI: u16 = 0x8000;
 
+fn has_flag(characteristics: u16, flag: u16) -> bool {
+    characteristics & flag == flag
+}
+
 pub fn is_dll(characteristics: u16) -> bool {
-    characteristics & IMAGE_FILE_DLL == IMAGE_FILE_DLL
+    has_flag(characteristics, IMAGE_FILE_DLL)
 }
 
 pub fn is_exe(characteristics: u16) -> bool {
-    characteristics & IMAGE_FILE_EXECUTABLE_IMAGE == IMAGE_FILE_EXECUTABLE_IMAGE
+    has_flag(characteristics, IMAGE_FILE_EXECUTABLE_IMAGE)
+}
+
+/// Validate the characteristics.
+///
+/// `is_image` being `true` indicates the characteristics is in a `PE`,
+/// being `false` indicates the characteristics is in a `Coff`.
+pub fn validate(characteristics: u16, is_image: bool) -> error::Result<()> {
+    let mut error_messages = vec![];
+    if is_image {
+        if !has_flag(characteristics, IMAGE_FILE_EXECUTABLE_IMAGE) {
+            error_messages
+                .push("If IMAGE_FILE_EXECUTABLE_IMAGE is not set, it indicates a linker error.");
+        }
+    } else {
+        if has_flag(characteristics, IMAGE_FILE_RELOCS_STRIPPED) {
+            error_messages.push("IMAGE_FILE_RELOCS_STRIPPED is image only.");
+        }
+        if has_flag(characteristics, IMAGE_FILE_EXECUTABLE_IMAGE) {
+            error_messages.push("IMAGE_FILE_EXECUTABLE_IMAGE is image only.");
+        }
+    }
+    if has_flag(characteristics, IMAGE_FILE_LINE_NUMS_STRIPPED) {
+        error_messages.push("IMAGE_FILE_LINE_NUMS_STRIPPED is deprecated and should be zero.")
+    }
+    if has_flag(characteristics, IMAGE_FILE_LOCAL_SYMS_STRIPPED) {
+        error_messages.push("IMAGE_FILE_LOCAL_SYMS_STRIPPED is deprecated and should be zero.")
+    }
+    if has_flag(characteristics, IMAGE_FILE_AGGRESSIVE_WS_TRIM) {
+        error_messages.push("IMAGE_FILE_AGGRESSIVE_WS_TRIM is deprecated and must be zero.");
+    }
+    if has_flag(characteristics, IMAGE_FILE_BYTES_REVERSED_LO) {
+        error_messages.push("IMAGE_FILE_BYTES_REVERSED_LO is deprecated and should be zero.");
+    }
+    if has_flag(characteristics, IMAGE_FILE_BYTES_REVERSED_HI) {
+        error_messages.push("IMAGE_FILE_BYTES_REVERSED_HI is deprecated and should be zero.");
+    }
+    if error_messages.is_empty() {
+        Ok(())
+    } else {
+        Err(error::Error::Malformed(error_messages.join("\n")))
+    }
 }

--- a/src/pe/characteristic.rs
+++ b/src/pe/characteristic.rs
@@ -111,8 +111,10 @@ pub fn validate(characteristics: u16, is_image: bool) -> error::Result<()> {
     let mut error_messages = vec![];
     if is_image {
         if !has_flag(characteristics, IMAGE_FILE_EXECUTABLE_IMAGE) {
-            error_messages
-                .push("If IMAGE_FILE_EXECUTABLE_IMAGE is not set, it indicates a linker error.".to_owned());
+            error_messages.push(
+                "If IMAGE_FILE_EXECUTABLE_IMAGE is not set, it indicates a linker error."
+                    .to_owned(),
+            );
         }
     } else {
         if has_flag(characteristics, IMAGE_FILE_RELOCS_STRIPPED) {
@@ -123,23 +125,30 @@ pub fn validate(characteristics: u16, is_image: bool) -> error::Result<()> {
         }
     }
     if has_flag(characteristics, IMAGE_FILE_LINE_NUMS_STRIPPED) {
-        error_messages.push("IMAGE_FILE_LINE_NUMS_STRIPPED is deprecated and should be zero.".to_owned())
+        error_messages
+            .push("IMAGE_FILE_LINE_NUMS_STRIPPED is deprecated and should be zero.".to_owned())
     }
     if has_flag(characteristics, IMAGE_FILE_LOCAL_SYMS_STRIPPED) {
-        error_messages.push("IMAGE_FILE_LOCAL_SYMS_STRIPPED is deprecated and should be zero.".to_owned())
+        error_messages
+            .push("IMAGE_FILE_LOCAL_SYMS_STRIPPED is deprecated and should be zero.".to_owned())
     }
     if has_flag(characteristics, IMAGE_FILE_AGGRESSIVE_WS_TRIM) {
-        error_messages.push("IMAGE_FILE_AGGRESSIVE_WS_TRIM is deprecated and must be zero.".to_owned());
+        error_messages
+            .push("IMAGE_FILE_AGGRESSIVE_WS_TRIM is deprecated and must be zero.".to_owned());
     }
     if has_flag(characteristics, IMAGE_FILE_BYTES_REVERSED_LO) {
-        error_messages.push("IMAGE_FILE_BYTES_REVERSED_LO is deprecated and should be zero.".to_owned());
+        error_messages
+            .push("IMAGE_FILE_BYTES_REVERSED_LO is deprecated and should be zero.".to_owned());
     }
     if has_flag(characteristics, IMAGE_FILE_BYTES_REVERSED_HI) {
-        error_messages.push("IMAGE_FILE_BYTES_REVERSED_HI is deprecated and should be zero.".to_owned());
+        error_messages
+            .push("IMAGE_FILE_BYTES_REVERSED_HI is deprecated and should be zero.".to_owned());
     }
     if error_messages.is_empty() {
         Ok(())
     } else {
-        Err(error::Error::Malformed(super::utils::organize_validation_error_messages("", error_messages)))
+        Err(error::Error::Malformed(
+            super::utils::organize_validation_error_messages("", error_messages),
+        ))
     }
 }

--- a/src/pe/characteristic.rs
+++ b/src/pe/characteristic.rs
@@ -112,34 +112,34 @@ pub fn validate(characteristics: u16, is_image: bool) -> error::Result<()> {
     if is_image {
         if !has_flag(characteristics, IMAGE_FILE_EXECUTABLE_IMAGE) {
             error_messages
-                .push("If IMAGE_FILE_EXECUTABLE_IMAGE is not set, it indicates a linker error.");
+                .push("If IMAGE_FILE_EXECUTABLE_IMAGE is not set, it indicates a linker error.".to_owned());
         }
     } else {
         if has_flag(characteristics, IMAGE_FILE_RELOCS_STRIPPED) {
-            error_messages.push("IMAGE_FILE_RELOCS_STRIPPED is image only.");
+            error_messages.push("IMAGE_FILE_RELOCS_STRIPPED is image only.".to_owned());
         }
         if has_flag(characteristics, IMAGE_FILE_EXECUTABLE_IMAGE) {
-            error_messages.push("IMAGE_FILE_EXECUTABLE_IMAGE is image only.");
+            error_messages.push("IMAGE_FILE_EXECUTABLE_IMAGE is image only.".to_owned());
         }
     }
     if has_flag(characteristics, IMAGE_FILE_LINE_NUMS_STRIPPED) {
-        error_messages.push("IMAGE_FILE_LINE_NUMS_STRIPPED is deprecated and should be zero.")
+        error_messages.push("IMAGE_FILE_LINE_NUMS_STRIPPED is deprecated and should be zero.".to_owned())
     }
     if has_flag(characteristics, IMAGE_FILE_LOCAL_SYMS_STRIPPED) {
-        error_messages.push("IMAGE_FILE_LOCAL_SYMS_STRIPPED is deprecated and should be zero.")
+        error_messages.push("IMAGE_FILE_LOCAL_SYMS_STRIPPED is deprecated and should be zero.".to_owned())
     }
     if has_flag(characteristics, IMAGE_FILE_AGGRESSIVE_WS_TRIM) {
-        error_messages.push("IMAGE_FILE_AGGRESSIVE_WS_TRIM is deprecated and must be zero.");
+        error_messages.push("IMAGE_FILE_AGGRESSIVE_WS_TRIM is deprecated and must be zero.".to_owned());
     }
     if has_flag(characteristics, IMAGE_FILE_BYTES_REVERSED_LO) {
-        error_messages.push("IMAGE_FILE_BYTES_REVERSED_LO is deprecated and should be zero.");
+        error_messages.push("IMAGE_FILE_BYTES_REVERSED_LO is deprecated and should be zero.".to_owned());
     }
     if has_flag(characteristics, IMAGE_FILE_BYTES_REVERSED_HI) {
-        error_messages.push("IMAGE_FILE_BYTES_REVERSED_HI is deprecated and should be zero.");
+        error_messages.push("IMAGE_FILE_BYTES_REVERSED_HI is deprecated and should be zero.".to_owned());
     }
     if error_messages.is_empty() {
         Ok(())
     } else {
-        Err(error::Error::Malformed(error_messages.join("\n")))
+        Err(error::Error::Malformed(super::utils::organize_validation_error_messages("", error_messages)))
     }
 }

--- a/src/pe/data_directories.rs
+++ b/src/pe/data_directories.rs
@@ -43,6 +43,23 @@ impl DataDirectories {
         }
         Ok(DataDirectories { data_directories })
     }
+    /// Validate the Data Directories.
+    pub fn validate(&self) -> error::Result<()> {
+        let mut error_messages = vec![];
+        if self.get_architecture().is_some() {
+            error_messages.push("Architecture field is reserved, must be 0.");
+        }
+        if let Some(global_ptr_directory) = self.get_global_ptr() {
+            if global_ptr_directory.size != 0 {
+                error_messages.push("The size member of Global Ptr must be set to zero.");
+            }
+        }
+        if error_messages.is_empty() {
+            Ok(())
+        } else {
+            Err(error::Error::Malformed(error_messages.join("\n")))
+        }
+    }
     pub fn get_export_table(&self) -> &Option<DataDirectory> {
         let idx = 0;
         unsafe { self.data_directories.get_unchecked(idx) }

--- a/src/pe/data_directories.rs
+++ b/src/pe/data_directories.rs
@@ -47,17 +47,17 @@ impl DataDirectories {
     pub fn validate(&self) -> error::Result<()> {
         let mut error_messages = vec![];
         if self.get_architecture().is_some() {
-            error_messages.push("Architecture field is reserved, must be 0.");
+            error_messages.push("Architecture field is reserved, must be 0.".to_owned());
         }
         if let Some(global_ptr_directory) = self.get_global_ptr() {
             if global_ptr_directory.size != 0 {
-                error_messages.push("The size member of Global Ptr must be set to zero.");
+                error_messages.push("The size member of Global Ptr must be set to zero.".to_owned());
             }
         }
         if error_messages.is_empty() {
             Ok(())
         } else {
-            Err(error::Error::Malformed(error_messages.join("\n")))
+            Err(error::Error::Malformed(super::utils::organize_validation_error_messages("", error_messages)))
         }
     }
     pub fn get_export_table(&self) -> &Option<DataDirectory> {

--- a/src/pe/data_directories.rs
+++ b/src/pe/data_directories.rs
@@ -51,13 +51,16 @@ impl DataDirectories {
         }
         if let Some(global_ptr_directory) = self.get_global_ptr() {
             if global_ptr_directory.size != 0 {
-                error_messages.push("The size member of Global Ptr must be set to zero.".to_owned());
+                error_messages
+                    .push("The size member of Global Ptr must be set to zero.".to_owned());
             }
         }
         if error_messages.is_empty() {
             Ok(())
         } else {
-            Err(error::Error::Malformed(super::utils::organize_validation_error_messages("", error_messages)))
+            Err(error::Error::Malformed(
+                super::utils::organize_validation_error_messages("", error_messages),
+            ))
         }
     }
     pub fn get_export_table(&self) -> &Option<DataDirectory> {

--- a/src/pe/data_directories.rs
+++ b/src/pe/data_directories.rs
@@ -1,4 +1,5 @@
 use crate::error;
+use alloc::borrow::ToOwned;
 use scroll::{Pread, Pwrite, SizeWith};
 
 #[repr(C)]

--- a/src/pe/header.rs
+++ b/src/pe/header.rs
@@ -41,6 +41,7 @@ impl DosHeader {
         if self.signature == DOS_MAGIC {
             Ok(())
         } else {
+            use alloc::string::String;
             Err(error::Error::Malformed(String::from(
                 "Unexpected DOS signature, expecting 0x5A4D.",
             )))
@@ -230,6 +231,7 @@ impl Header {
             error_messages.push(error_message);
         }
         if self.signature != PE_MAGIC {
+            use alloc::string::String;
             error_messages.push(String::from(
                 r#"Unexpected PE signature, expecting "PE\0\0" in little endian."#,
             ));

--- a/src/pe/header.rs
+++ b/src/pe/header.rs
@@ -2,6 +2,7 @@ use crate::error;
 use crate::pe::{optional_header, section_table, symbol};
 use crate::strtab;
 use alloc::vec::Vec;
+use alloc::string::String;
 use log::debug;
 use scroll::{IOread, IOwrite, Pread, Pwrite, SizeWith};
 
@@ -41,7 +42,6 @@ impl DosHeader {
         if self.signature == DOS_MAGIC {
             Ok(())
         } else {
-            use alloc::string::String;
             Err(error::Error::Malformed(String::from(
                 "Unexpected DOS signature, expecting 0x5A4D.",
             )))
@@ -169,14 +169,14 @@ impl CoffHeader {
         let mut error_messages = vec![];
         if is_image {
             if self.pointer_to_symbol_table != 0 {
-                error_messages.push("PointerToSymbolTable should be zero for an image because COFF debugging information is deprecated.");
+                error_messages.push("PointerToSymbolTable should be zero for an image because COFF debugging information is deprecated.".to_owned());
             }
             if self.number_of_symbol_table != 0 {
-                error_messages.push("NumberOfSymbols should be zero for an image because COFF debugging information is deprecated.");
+                error_messages.push("NumberOfSymbols should be zero for an image because COFF debugging information is deprecated.".to_owned());
             }
         } else {
             if self.size_of_optional_header != 0 {
-                error_messages.push("SizeOfOptionalHeader should be zero for an object file.");
+                error_messages.push("SizeOfOptionalHeader should be zero for an object file.".to_owned());
             }
         }
         let characteristic_error_message;
@@ -184,12 +184,12 @@ impl CoffHeader {
             super::characteristic::validate(self.characteristics, is_image)
         {
             characteristic_error_message = error_message.clone();
-            error_messages.push(&characteristic_error_message);
+            error_messages.push(characteristic_error_message);
         }
         if error_messages.is_empty() {
             Ok(())
         } else {
-            Err(error::Error::Malformed(error_messages.join("\n")))
+            Err(error::Error::Malformed(super::utils::organize_validation_error_messages("", error_messages)))
         }
     }
 }
@@ -231,7 +231,6 @@ impl Header {
             error_messages.push(error_message);
         }
         if self.signature != PE_MAGIC {
-            use alloc::string::String;
             error_messages.push(String::from(
                 r#"Unexpected PE signature, expecting "PE\0\0" in little endian."#,
             ));
@@ -247,7 +246,7 @@ impl Header {
         if error_messages.is_empty() {
             Ok(())
         } else {
-            Err(error::Error::Malformed(error_messages.join("\n")))
+            Err(error::Error::Malformed(super::utils::organize_validation_error_messages("", error_messages)))
         }
     }
 }

--- a/src/pe/header.rs
+++ b/src/pe/header.rs
@@ -1,8 +1,8 @@
 use crate::error;
 use crate::pe::{optional_header, section_table, symbol};
 use crate::strtab;
-use alloc::vec::Vec;
 use alloc::string::String;
+use alloc::vec::Vec;
 use log::debug;
 use scroll::{IOread, IOwrite, Pread, Pwrite, SizeWith};
 
@@ -176,7 +176,8 @@ impl CoffHeader {
             }
         } else {
             if self.size_of_optional_header != 0 {
-                error_messages.push("SizeOfOptionalHeader should be zero for an object file.".to_owned());
+                error_messages
+                    .push("SizeOfOptionalHeader should be zero for an object file.".to_owned());
             }
         }
         let characteristic_error_message;
@@ -189,7 +190,9 @@ impl CoffHeader {
         if error_messages.is_empty() {
             Ok(())
         } else {
-            Err(error::Error::Malformed(super::utils::organize_validation_error_messages("", error_messages)))
+            Err(error::Error::Malformed(
+                super::utils::organize_validation_error_messages("", error_messages),
+            ))
         }
     }
 }
@@ -246,7 +249,9 @@ impl Header {
         if error_messages.is_empty() {
             Ok(())
         } else {
-            Err(error::Error::Malformed(super::utils::organize_validation_error_messages("", error_messages)))
+            Err(error::Error::Malformed(
+                super::utils::organize_validation_error_messages("", error_messages),
+            ))
         }
     }
 }

--- a/src/pe/header.rs
+++ b/src/pe/header.rs
@@ -1,6 +1,7 @@
 use crate::error;
 use crate::pe::{optional_header, section_table, symbol};
 use crate::strtab;
+use alloc::borrow::ToOwned;
 use alloc::string::String;
 use alloc::vec::Vec;
 use log::debug;

--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -176,6 +176,24 @@ impl<'a> PE<'a> {
             exception_data,
         })
     }
+
+    /// Validate the `PE`
+    pub fn validate(&self) -> error::Result<()> {
+        let mut error_messages = vec![];
+        if let Err(error::Error::Malformed(error_message)) = self.header.validate() {
+            error_messages.push(error_message);
+        }
+        for section in &self.sections {
+            if let Err(error::Error::Malformed(error_message)) = section.validate(true) {
+                error_messages.push(error_message);
+            }
+        }
+        if error_messages.is_empty() {
+            Ok(())
+        } else {
+            Err(error::Error::Malformed(error_messages.join("\n")))
+        }
+    }
 }
 
 /// An analyzed COFF object
@@ -208,5 +226,23 @@ impl<'a> Coff<'a> {
             symbols,
             strings,
         })
+    }
+
+    /// Validate the `COFF`
+    pub fn validate(&self) -> error::Result<()> {
+        let mut error_messages = vec![];
+        if let Err(error::Error::Malformed(error_message)) = self.header.validate(false) {
+            error_messages.push(error_message);
+        }
+        for section in &self.sections {
+            if let Err(error::Error::Malformed(error_message)) = section.validate(false) {
+                error_messages.push(error_message);
+            }
+        }
+        if error_messages.is_empty() {
+            Ok(())
+        } else {
+            Err(error::Error::Malformed(error_messages.join("\n")))
+        }
     }
 }

--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -191,7 +191,7 @@ impl<'a> PE<'a> {
         if error_messages.is_empty() {
             Ok(())
         } else {
-            Err(error::Error::Malformed(error_messages.join("\n")))
+            Err(error::Error::Malformed(utils::organize_validation_error_messages("", error_messages)))
         }
     }
 }
@@ -242,7 +242,7 @@ impl<'a> Coff<'a> {
         if error_messages.is_empty() {
             Ok(())
         } else {
-            Err(error::Error::Malformed(error_messages.join("\n")))
+            Err(error::Error::Malformed(utils::organize_validation_error_messages("", error_messages)))
         }
     }
 }

--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -191,7 +191,9 @@ impl<'a> PE<'a> {
         if error_messages.is_empty() {
             Ok(())
         } else {
-            Err(error::Error::Malformed(utils::organize_validation_error_messages("", error_messages)))
+            Err(error::Error::Malformed(
+                utils::organize_validation_error_messages("", error_messages),
+            ))
         }
     }
 }
@@ -242,7 +244,9 @@ impl<'a> Coff<'a> {
         if error_messages.is_empty() {
             Ok(())
         } else {
-            Err(error::Error::Malformed(utils::organize_validation_error_messages("", error_messages)))
+            Err(error::Error::Malformed(
+                utils::organize_validation_error_messages("", error_messages),
+            ))
         }
     }
 }

--- a/src/pe/optional_header.rs
+++ b/src/pe/optional_header.rs
@@ -243,22 +243,22 @@ impl WindowsFields {
     pub fn validate(&self) -> error::Result<()> {
         let mut error_messages = vec![];
         if self.image_base % 0x1000 != 0 {
-            error_messages.push("ImageBase must be a multiple of 64K.");
+            error_messages.push("ImageBase must be a multiple of 64K.".to_owned());
         }
         if self.section_alignment < self.file_alignment {
-            error_messages.push("SectionAlignment must be greater than or equal to FileAlignment.");
+            error_messages.push("SectionAlignment must be greater than or equal to FileAlignment.".to_owned());
         }
         if self.file_alignment < 512 || self.file_alignment > 0x1000 || self.file_alignment % 2 != 0
         {
-            error_messages.push("FileAlignment should be a power of 2 between 512 and 64K.");
+            error_messages.push("FileAlignment should be a power of 2 between 512 and 64K.".to_owned());
         }
         if self.size_of_image % self.section_alignment != 0 {
-            error_messages.push("SizeOfImage must be a multiple of SectionAlignment.");
+            error_messages.push("SizeOfImage must be a multiple of SectionAlignment.".to_owned());
         }
         if error_messages.is_empty() {
             Ok(())
         } else {
-            Err(error::Error::Malformed(error_messages.join("\n")))
+            Err(error::Error::Malformed(super::utils::organize_validation_error_messages("", error_messages)))
         }
     }
 }
@@ -291,7 +291,7 @@ impl OptionalHeader {
         if error_messages.is_empty() {
             Ok(())
         } else {
-            Err(error::Error::Malformed(error_messages.join("\n")))
+            Err(error::Error::Malformed(super::utils::organize_validation_error_messages("", error_messages)))
         }
     }
 }

--- a/src/pe/optional_header.rs
+++ b/src/pe/optional_header.rs
@@ -3,6 +3,7 @@ use crate::error;
 
 use crate::pe::data_directories;
 
+use alloc::borrow::ToOwned;
 use scroll::{ctx, Endian, LE};
 use scroll::{Pread, Pwrite, SizeWith};
 

--- a/src/pe/optional_header.rs
+++ b/src/pe/optional_header.rs
@@ -246,11 +246,14 @@ impl WindowsFields {
             error_messages.push("ImageBase must be a multiple of 64K.".to_owned());
         }
         if self.section_alignment < self.file_alignment {
-            error_messages.push("SectionAlignment must be greater than or equal to FileAlignment.".to_owned());
+            error_messages.push(
+                "SectionAlignment must be greater than or equal to FileAlignment.".to_owned(),
+            );
         }
         if self.file_alignment < 512 || self.file_alignment > 0x1000 || self.file_alignment % 2 != 0
         {
-            error_messages.push("FileAlignment should be a power of 2 between 512 and 64K.".to_owned());
+            error_messages
+                .push("FileAlignment should be a power of 2 between 512 and 64K.".to_owned());
         }
         if self.size_of_image % self.section_alignment != 0 {
             error_messages.push("SizeOfImage must be a multiple of SectionAlignment.".to_owned());
@@ -258,7 +261,9 @@ impl WindowsFields {
         if error_messages.is_empty() {
             Ok(())
         } else {
-            Err(error::Error::Malformed(super::utils::organize_validation_error_messages("", error_messages)))
+            Err(error::Error::Malformed(
+                super::utils::organize_validation_error_messages("", error_messages),
+            ))
         }
     }
 }
@@ -291,7 +296,9 @@ impl OptionalHeader {
         if error_messages.is_empty() {
             Ok(())
         } else {
-            Err(error::Error::Malformed(super::utils::organize_validation_error_messages("", error_messages)))
+            Err(error::Error::Malformed(
+                super::utils::organize_validation_error_messages("", error_messages),
+            ))
         }
     }
 }

--- a/src/pe/section_table.rs
+++ b/src/pe/section_table.rs
@@ -1,5 +1,6 @@
 use crate::error::{self, Error};
 use crate::pe::relocation;
+use alloc::borrow::ToOwned;
 use alloc::string::{String, ToString};
 use scroll::{ctx, Pread, Pwrite};
 

--- a/src/pe/section_table.rs
+++ b/src/pe/section_table.rs
@@ -172,40 +172,38 @@ impl SectionTable {
         let mut error_messages = vec![];
         if is_image {
             if self.name[0] == b'/' {
-                error_messages.push("Executable images do not use a string table and do not support section names longer than 8 characters.");
+                error_messages.push("Executable images do not use a string table and do not support section names longer than 8 characters.".to_owned());
             }
             // TODO: Validate `size_of_raw_data` field as: For executable images, this must be a multiple of FileAlignment from the optional header.
             // TODO: Validate `pointer_to_raw_data` field as: For executable images, this must be a multiple of FileAlignment from the optional header.
             if self.pointer_to_relocations != 0 {
-                error_messages.push("PointerToRelocations is set to zero for executable images.");
+                error_messages.push("PointerToRelocations is set to zero for executable images.".to_owned());
             }
             if self.pointer_to_linenumbers != 0 {
-                error_messages.push("PointerToLinenumbers should be zero for an image because COFF debugging information is deprecated.");
+                error_messages.push("PointerToLinenumbers should be zero for an image because COFF debugging information is deprecated.".to_owned());
             }
             if self.number_of_relocations != 0 {
                 error_messages
-                    .push("NumberOfRelocations should be set to zero for executable images.");
+                    .push("NumberOfRelocations should be set to zero for executable images.".to_owned());
             }
             if self.number_of_linenumbers != 0 {
-                error_messages.push("NumberOfLinenumbers shuold be zero for an image because COFF debugging information is deprecated.");
+                error_messages.push("NumberOfLinenumbers shuold be zero for an image because COFF debugging information is deprecated.".to_owned());
             }
             if self.name.contains(&b'$') {
                 error_messages
-                    .push(r#"The section name in an image file never contains a "$"? character."#);
+                    .push(r#"The section name in an image file never contains a "$"? character."#.to_owned());
             }
         } else {
             if self.virtual_size != 0 {
-                error_messages.push("VirtualSize field should be set zero for object files.");
+                error_messages.push("VirtualSize field should be set zero for object files.".to_owned());
             }
         }
         if error_messages.is_empty() {
             Ok(())
         } else {
-            Err(error::Error::Malformed(format!(
-                "For section {}:\n{}",
-                String::from_utf8_lossy(&self.name),
-                error_messages.join("\n")
-            )))
+            Err(error::Error::Malformed(
+                super::utils::organize_validation_error_messages(&String::from_utf8_lossy(&self.name), error_messages)
+            ))
         }
     }
 }

--- a/src/pe/section_table.rs
+++ b/src/pe/section_table.rs
@@ -177,32 +177,40 @@ impl SectionTable {
             // TODO: Validate `size_of_raw_data` field as: For executable images, this must be a multiple of FileAlignment from the optional header.
             // TODO: Validate `pointer_to_raw_data` field as: For executable images, this must be a multiple of FileAlignment from the optional header.
             if self.pointer_to_relocations != 0 {
-                error_messages.push("PointerToRelocations is set to zero for executable images.".to_owned());
+                error_messages
+                    .push("PointerToRelocations is set to zero for executable images.".to_owned());
             }
             if self.pointer_to_linenumbers != 0 {
                 error_messages.push("PointerToLinenumbers should be zero for an image because COFF debugging information is deprecated.".to_owned());
             }
             if self.number_of_relocations != 0 {
-                error_messages
-                    .push("NumberOfRelocations should be set to zero for executable images.".to_owned());
+                error_messages.push(
+                    "NumberOfRelocations should be set to zero for executable images.".to_owned(),
+                );
             }
             if self.number_of_linenumbers != 0 {
                 error_messages.push("NumberOfLinenumbers shuold be zero for an image because COFF debugging information is deprecated.".to_owned());
             }
             if self.name.contains(&b'$') {
-                error_messages
-                    .push(r#"The section name in an image file never contains a "$"? character."#.to_owned());
+                error_messages.push(
+                    r#"The section name in an image file never contains a "$"? character."#
+                        .to_owned(),
+                );
             }
         } else {
             if self.virtual_size != 0 {
-                error_messages.push("VirtualSize field should be set zero for object files.".to_owned());
+                error_messages
+                    .push("VirtualSize field should be set zero for object files.".to_owned());
             }
         }
         if error_messages.is_empty() {
             Ok(())
         } else {
             Err(error::Error::Malformed(
-                super::utils::organize_validation_error_messages(&String::from_utf8_lossy(&self.name), error_messages)
+                super::utils::organize_validation_error_messages(
+                    &String::from_utf8_lossy(&self.name),
+                    error_messages,
+                ),
             ))
         }
     }

--- a/src/pe/section_table.rs
+++ b/src/pe/section_table.rs
@@ -163,6 +163,51 @@ impl SectionTable {
         let number = self.number_of_relocations as usize;
         relocation::Relocations::parse(bytes, offset, number)
     }
+
+    /// Validate the `SectionTable`.
+    ///
+    /// `is_image` being `true` indicates the `SectionTable` is in a `PE`,
+    /// being `false` indicates the `SectionTable` is in a `Coff`.
+    pub fn validate(&self, is_image: bool) -> error::Result<()> {
+        let mut error_messages = vec![];
+        if is_image {
+            if self.name[0] == b'/' {
+                error_messages.push("Executable images do not use a string table and do not support section names longer than 8 characters.");
+            }
+            // TODO: Validate `size_of_raw_data` field as: For executable images, this must be a multiple of FileAlignment from the optional header.
+            // TODO: Validate `pointer_to_raw_data` field as: For executable images, this must be a multiple of FileAlignment from the optional header.
+            if self.pointer_to_relocations != 0 {
+                error_messages.push("PointerToRelocations is set to zero for executable images.");
+            }
+            if self.pointer_to_linenumbers != 0 {
+                error_messages.push("PointerToLinenumbers should be zero for an image because COFF debugging information is deprecated.");
+            }
+            if self.number_of_relocations != 0 {
+                error_messages
+                    .push("NumberOfRelocations should be set to zero for executable images.");
+            }
+            if self.number_of_linenumbers != 0 {
+                error_messages.push("NumberOfLinenumbers shuold be zero for an image because COFF debugging information is deprecated.");
+            }
+            if self.name.contains(&b'$') {
+                error_messages
+                    .push(r#"The section name in an image file never contains a "$"? character."#);
+            }
+        } else {
+            if self.virtual_size != 0 {
+                error_messages.push("VirtualSize field should be set zero for object files.");
+            }
+        }
+        if error_messages.is_empty() {
+            Ok(())
+        } else {
+            Err(error::Error::Malformed(format!(
+                "For section {}:\n{}",
+                String::from_utf8_lossy(&self.name),
+                error_messages.join("\n")
+            )))
+        }
+    }
 }
 
 impl ctx::SizeWith<scroll::Endian> for SectionTable {

--- a/src/pe/utils.rs
+++ b/src/pe/utils.rs
@@ -6,6 +6,8 @@ use super::section_table;
 
 use crate::pe::data_directories::DataDirectory;
 use core::cmp;
+use alloc::vec::Vec;
+use alloc::string::String;
 
 use log::debug;
 
@@ -124,4 +126,17 @@ where
         .ok_or_else(|| error::Error::Malformed(directory.virtual_address.to_string()))?;
     let result: T = bytes.pread_with(offset, scroll::LE)?;
     Ok(result)
+}
+
+/// Equivalent to `format!("{}{}", prefix, error_messages.join("\n"))`, which can't compile in some old version of Rust with alloc and core.
+pub(crate) fn organize_validation_error_messages(prefix: &str, error_messages: Vec<String>) -> String {
+    let mut message = String::new();
+    message.push_str(prefix);
+    for (index, error_message) in error_messages.iter().enumerate() {
+        if index != 0 {
+            message.push('\n');
+        }
+        message.push_str(&error_message);
+    }
+    message
 }

--- a/src/pe/utils.rs
+++ b/src/pe/utils.rs
@@ -5,9 +5,9 @@ use scroll::Pread;
 use super::section_table;
 
 use crate::pe::data_directories::DataDirectory;
-use core::cmp;
-use alloc::vec::Vec;
 use alloc::string::String;
+use alloc::vec::Vec;
+use core::cmp;
 
 use log::debug;
 
@@ -129,7 +129,10 @@ where
 }
 
 /// Equivalent to `format!("{}{}", prefix, error_messages.join("\n"))`, which can't compile in some old version of Rust with alloc and core.
-pub(crate) fn organize_validation_error_messages(prefix: &str, error_messages: Vec<String>) -> String {
+pub(crate) fn organize_validation_error_messages(
+    prefix: &str,
+    error_messages: Vec<String>,
+) -> String {
     let mut message = String::new();
     message.push_str(prefix);
     for (index, error_message) in error_messages.iter().enumerate() {


### PR DESCRIPTION
From the Microsoft [PE format](https://docs.microsoft.com/en-us/windows/win32/debug/pe-format) spec, we can do some basic validations for the parsed PE and COFF object, such as some fields should be set to zero for PE image but not for COFF object.

The validation is very basic and can be further completed in the future.