### PR TITLE
Exposing the raw COFF section table to the user

### DIFF
--- a/src/pe/header.rs
+++ b/src/pe/header.rs
@@ -56,6 +56,8 @@ pub const SIZEOF_COFF_HEADER: usize = 20;
 /// PE\0\0, little endian
 pub const PE_MAGIC: u32 = 0x0000_4550;
 pub const SIZEOF_PE_MAGIC: usize = 4;
+// sizeof(IMAGE_SECTION_HEADER), used for header calculations
+pub const SIZEOF_IMAGE_SECTION_HEADER: usize = 40;
 /// The contents of this field are assumed to be applicable to any machine type
 pub const COFF_MACHINE_UNKNOWN: u16 = 0x0;
 /// Matsushita AM33

--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -57,7 +57,7 @@ pub struct PE<'a> {
     pub debug_data: Option<debug::DebugData<'a>>,
     /// Exception handling and stack unwind information, if any, contained in the PE header
     pub exception_data: Option<exception::ExceptionData<'a>>,
-    pub section_table: &'a [u8]
+    pub section_table: &'a [u8],
 }
 
 impl<'a> PE<'a> {
@@ -70,15 +70,16 @@ impl<'a> PE<'a> {
             + header::SIZEOF_COFF_HEADER
             + header.coff_header.size_of_optional_header as usize);
 
-        let min_size = *offset + header.coff_header.number_of_sections as usize * header::SIZEOF_IMAGE_SECTION_HEADER;
+        let min_size = *offset
+            + header.coff_header.number_of_sections as usize * header::SIZEOF_IMAGE_SECTION_HEADER;
 
         if bytes.len() < min_size {
             // The section table contains more entries than the binary can provide given the size
-            return Err(
-                error::Error::Malformed(
-                    format!("Corrupted PE: Expected at least {:#X} bytes but got {:#X}", min_size, bytes.len())
-                )
-            )
+            return Err(error::Error::Malformed(format!(
+                "Corrupted PE: Expected at least {:#X} bytes but got {:#X}",
+                min_size,
+                bytes.len()
+            )));
         }
 
         let section_table = &bytes[*offset..min_size];
@@ -189,7 +190,7 @@ impl<'a> PE<'a> {
             libraries,
             debug_data,
             exception_data,
-            section_table
+            section_table,
         })
     }
 }

--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -57,6 +57,7 @@ pub struct PE<'a> {
     pub debug_data: Option<debug::DebugData<'a>>,
     /// Exception handling and stack unwind information, if any, contained in the PE header
     pub exception_data: Option<exception::ExceptionData<'a>>,
+    pub section_table: &'a [u8]
 }
 
 impl<'a> PE<'a> {
@@ -68,6 +69,20 @@ impl<'a> PE<'a> {
             + header::SIZEOF_PE_MAGIC
             + header::SIZEOF_COFF_HEADER
             + header.coff_header.size_of_optional_header as usize);
+
+        let min_size = *offset + header.coff_header.number_of_sections as usize * header::SIZEOF_IMAGE_SECTION_HEADER;
+
+        if bytes.len() < min_size {
+            // The section table contains more entries than the binary can provide given the size
+            return Err(
+                error::Error::Malformed(
+                    format!("Corrupted PE: Expected at least {:#X} bytes but got {:#X}", min_size, bytes.len())
+                )
+            )
+        }
+
+        let section_table = &bytes[*offset..min_size];
+
         let sections = header.coff_header.sections(bytes, offset)?;
         let is_lib = characteristic::is_dll(header.coff_header.characteristics);
         let mut entry = 0;
@@ -174,6 +189,7 @@ impl<'a> PE<'a> {
             libraries,
             debug_data,
             exception_data,
+            section_table
         })
     }
 }

--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -57,6 +57,7 @@ pub struct PE<'a> {
     pub debug_data: Option<debug::DebugData<'a>>,
     /// Exception handling and stack unwind information, if any, contained in the PE header
     pub exception_data: Option<exception::ExceptionData<'a>>,
+    /// The raw, unparsed section table.
     pub section_table: &'a [u8],
 }
 
@@ -70,19 +71,19 @@ impl<'a> PE<'a> {
             + header::SIZEOF_COFF_HEADER
             + header.coff_header.size_of_optional_header as usize);
 
-        let min_size = *offset
+        let section_end_offset = *offset
             + header.coff_header.number_of_sections as usize * header::SIZEOF_IMAGE_SECTION_HEADER;
 
-        if bytes.len() < min_size {
+        if bytes.len() < section_end_offset {
             // The section table contains more entries than the binary can provide given the size
             return Err(error::Error::Malformed(format!(
                 "Corrupted PE: Expected at least {:#X} bytes but got {:#X}",
-                min_size,
+                section_end_offset,
                 bytes.len()
             )));
         }
 
-        let section_table = &bytes[*offset..min_size];
+        let section_table = &bytes[*offset..section_end_offset];
 
         let sections = header.coff_header.sections(bytes, offset)?;
         let is_lib = characteristic::is_dll(header.coff_header.characteristics);


### PR DESCRIPTION
I'm working on something that requires raw access to the section table and figured I might as well add this to the library so others may make use of this. 
I tried building upon the existing code but I didn't want to break the signature of `header.coff_header.sections` either.

This shouldn't break anything and should also add some validation for broken PEs. 