### PR TITLE
Fix size check for section headers

### DIFF
--- a/src/elf/section_header.rs
+++ b/src/elf/section_header.rs
@@ -473,8 +473,8 @@ if_alloc! {
                     self.sh_name, self.sh_offset, self.sh_size, overflow);
                 return Err(error::Error::Malformed(message));
             }
-            let (end, overflow) = self.sh_addr.overflowing_add(self.sh_size);
-            if overflow || end > size as u64 {
+            let (_, overflow) = self.sh_addr.overflowing_add(self.sh_size);
+            if overflow {
                 let message = format!("Section {} size ({}) + addr ({}) is out of bounds. Overflowed: {}",
                     self.sh_name, self.sh_addr, self.sh_size, overflow);
                 return Err(error::Error::Malformed(message));


### PR DESCRIPTION
The section header size check introduced in #243 compares the virtual memory
address range `sh_addr` with the physical file size. This leads to a
false-positive invariant violation and fails to parse valid ELF files.

See also https://github.com/m4b/bingrep/issues/28

cc @jackmay
