### PR TITLE
Return an empty file range for SHT_NOBITS sections

### DIFF
--- a/src/elf/section_header.rs
+++ b/src/elf/section_header.rs
@@ -428,7 +428,13 @@ if_alloc! {
         }
         /// Returns this section header's file offset range
         pub fn file_range(&self) -> Range<usize> {
-            self.sh_offset as usize..(self.sh_offset as usize).saturating_add(self.sh_size as usize)
+            // Sections with type SHT_NOBITS have no data in the file itself,
+            // they only exist in memory.
+            if self.sh_type == SHT_NOBITS {
+                self.sh_offset as usize..self.sh_offset as usize
+            } else {
+                self.sh_offset as usize..(self.sh_offset as usize).saturating_add(self.sh_size as usize)
+            }
         }
         /// Returns this section header's virtual memory range
         pub fn vm_range(&self) -> Range<usize> {

--- a/src/elf/section_header.rs
+++ b/src/elf/section_header.rs
@@ -426,14 +426,15 @@ if_alloc! {
                 sh_entsize: 0,
             }
         }
-        /// Returns this section header's file offset range
-        pub fn file_range(&self) -> Range<usize> {
+        /// Returns this section header's file offset range,
+        /// if the section occupies space in fhe file.
+        pub fn file_range(&self) -> Option<Range<usize>> {
             // Sections with type SHT_NOBITS have no data in the file itself,
             // they only exist in memory.
             if self.sh_type == SHT_NOBITS {
-                self.sh_offset as usize..self.sh_offset as usize
+                None
             } else {
-                self.sh_offset as usize..(self.sh_offset as usize).saturating_add(self.sh_size as usize)
+                Some(self.sh_offset as usize..(self.sh_offset as usize).saturating_add(self.sh_size as usize))
             }
         }
         /// Returns this section header's virtual memory range


### PR DESCRIPTION
ELF sections with type SHT_NOBITS only exist in memory, and
don't contain any data in the ELF file itself. The range
returned by `file_range()` should be empty for such sections.

The previously returned range was wrong, and overlapped
the file range of the next section.

Fixes #252.
