### PR TITLE
Fix arithmetic debug assertions in elf

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -21,3 +21,7 @@ members = ["."]
 [[bin]]
 name = "parse"
 path = "fuzz_targets/parse.rs"
+
+[[bin]]
+name = "parse_elf"
+path = "fuzz_targets/parse_elf.rs"

--- a/fuzz/fuzz_targets/parse_elf.rs
+++ b/fuzz/fuzz_targets/parse_elf.rs
@@ -1,0 +1,24 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(elf) = goblin::elf::Elf::parse(data) {
+        for section_header in &elf.section_headers {
+            let _ = elf.shdr_strtab.get(section_header.sh_name);
+        }
+
+        for _relocation in &elf.dynrels {}
+
+        if let Some(mut it) = elf.iter_note_headers(data) {
+            while let Some(Ok(_a)) = it.next() {}
+        }
+
+        if let Some(mut it) = elf.iter_note_sections(data, None) {
+            while let Some(Ok(_a)) = it.next() {}
+        }
+
+        if let Some(mut it) = elf.iter_note_sections(data, Some("x")) {
+            while let Some(Ok(_a)) = it.next() {}
+        }
+    }
+});

--- a/src/elf/mod.rs
+++ b/src/elf/mod.rs
@@ -145,7 +145,7 @@ if_sylvan! {
                     iters.push(note::NoteDataIterator {
                         data,
                         offset,
-                        size: offset + phdr.p_filesz as usize,
+                        size: offset.saturating_add(phdr.p_filesz as usize),
                         ctx: (alignment, self.ctx)
                     });
                 }
@@ -185,7 +185,7 @@ if_sylvan! {
                 iters.push(note::NoteDataIterator {
                     data,
                     offset,
-                    size: offset + sect.sh_size as usize,
+                    size: offset.saturating_add(sect.sh_size as usize),
                     ctx: (alignment, self.ctx)
                 });
             }
@@ -406,9 +406,9 @@ if_sylvan! {
     fn hash_len(bytes: &[u8], offset: usize, machine: u16, ctx: Ctx) -> error::Result<usize> {
         // Based on readelf code.
         let nchain = if (machine == header::EM_FAKE_ALPHA || machine == header::EM_S390) && ctx.container.is_big() {
-            bytes.pread_with::<u64>(offset + 4, ctx.le)? as usize
+            bytes.pread_with::<u64>(offset.saturating_add(4), ctx.le)? as usize
         } else {
-            bytes.pread_with::<u32>(offset + 4, ctx.le)? as usize
+            bytes.pread_with::<u32>(offset.saturating_add(4), ctx.le)? as usize
         };
         Ok(nchain)
     }


### PR DESCRIPTION
This adds a new fuzzing harness that covers most of the ELF module and fixes a few overflow assertions.

`saturating_add`s should be fine since all of the edge cases concern sizes that are bounds-checked later.

(Xref #110)