### PR TITLE
Remove unneeded unsafe in data_directories.rs

### DIFF
--- a/src/pe/data_directories.rs
+++ b/src/pe/data_directories.rs
@@ -45,62 +45,62 @@ impl DataDirectories {
     }
     pub fn get_export_table(&self) -> &Option<DataDirectory> {
         let idx = 0;
-        unsafe { self.data_directories.get_unchecked(idx) }
+        &self.data_directories[idx]
     }
     pub fn get_import_table(&self) -> &Option<DataDirectory> {
         let idx = 1;
-        unsafe { self.data_directories.get_unchecked(idx) }
+        &self.data_directories[idx]
     }
     pub fn get_resource_table(&self) -> &Option<DataDirectory> {
         let idx = 2;
-        unsafe { self.data_directories.get_unchecked(idx) }
+        &self.data_directories[idx]
     }
     pub fn get_exception_table(&self) -> &Option<DataDirectory> {
         let idx = 3;
-        unsafe { self.data_directories.get_unchecked(idx) }
+        &self.data_directories[idx]
     }
     pub fn get_certificate_table(&self) -> &Option<DataDirectory> {
         let idx = 4;
-        unsafe { self.data_directories.get_unchecked(idx) }
+        &self.data_directories[idx]
     }
     pub fn get_base_relocation_table(&self) -> &Option<DataDirectory> {
         let idx = 5;
-        unsafe { self.data_directories.get_unchecked(idx) }
+        &self.data_directories[idx]
     }
     pub fn get_debug_table(&self) -> &Option<DataDirectory> {
         let idx = 6;
-        unsafe { self.data_directories.get_unchecked(idx) }
+        &self.data_directories[idx]
     }
     pub fn get_architecture(&self) -> &Option<DataDirectory> {
         let idx = 7;
-        unsafe { self.data_directories.get_unchecked(idx) }
+        &self.data_directories[idx]
     }
     pub fn get_global_ptr(&self) -> &Option<DataDirectory> {
         let idx = 8;
-        unsafe { self.data_directories.get_unchecked(idx) }
+        &self.data_directories[idx]
     }
     pub fn get_tls_table(&self) -> &Option<DataDirectory> {
         let idx = 9;
-        unsafe { self.data_directories.get_unchecked(idx) }
+        &self.data_directories[idx]
     }
     pub fn get_load_config_table(&self) -> &Option<DataDirectory> {
         let idx = 10;
-        unsafe { self.data_directories.get_unchecked(idx) }
+        &self.data_directories[idx]
     }
     pub fn get_bound_import_table(&self) -> &Option<DataDirectory> {
         let idx = 11;
-        unsafe { self.data_directories.get_unchecked(idx) }
+        &self.data_directories[idx]
     }
     pub fn get_import_address_table(&self) -> &Option<DataDirectory> {
         let idx = 12;
-        unsafe { self.data_directories.get_unchecked(idx) }
+        &self.data_directories[idx]
     }
     pub fn get_delay_import_descriptor(&self) -> &Option<DataDirectory> {
         let idx = 13;
-        unsafe { self.data_directories.get_unchecked(idx) }
+        &self.data_directories[idx]
     }
     pub fn get_clr_runtime_header(&self) -> &Option<DataDirectory> {
         let idx = 14;
-        unsafe { self.data_directories.get_unchecked(idx) }
+        &self.data_directories[idx]
     }
 }


### PR DESCRIPTION
This pull request replaces get_unchecked calls with direct indexing ( [] ). This removes a bunch of unsafe blocks

As far as I can tell, this should not affect optimized code: Since rust statically knows the size of the array, it should be able to elide the bounds checks

This [godbolt link](https://rust.godbolt.org/z/Pd19W6) shows how both the version with and without the unsafe are compiled to the same function with opt-level=3. [This](https://rust.godbolt.org/z/Wrb3eT) is the same example without the derives adding noise to the output

What I found interesting is, according to [this godbolt link](https://rust.godbolt.org/z/4dzs53) when compiling without optimizations, rust also elides the bounds checks for the indexing version, and the get_unchecked version has to call the get_unchecked function which does not get inlined
![imagen](https://user-images.githubusercontent.com/24706838/107867089-4fccd980-6e56-11eb-8fbb-b729d337fd7c.png)


So I would expect the new version to outperform the unsafe version on debug builds, and match the unsafe version with optimizations