### PR TITLE
build: fix error when alloc, but not endian_fd

### DIFF
--- a/src/elf/reloc.rs
+++ b/src/elf/reloc.rs
@@ -280,7 +280,6 @@ if_alloc! {
     use core::fmt;
     use core::result;
     use crate::container::{Ctx, Container};
-    #[cfg(feature = "endian_fd")]
     use alloc::vec::Vec;
 
     #[derive(Clone, Copy, PartialEq, Default)]


### PR DESCRIPTION
See issue #272 for details.

Signed-off-by: Dan Cross <cross@gajendra.net>