### PR TITLE
Never return a section size smaller than virtual size

### DIFF
--- a/src/pe/utils.rs
+++ b/src/pe/utils.rs
@@ -32,9 +32,9 @@ fn section_read_size(section: &section_table::SectionTable, file_alignment: u32)
     let size_of_raw_data = section.size_of_raw_data as usize;
     let virtual_size = section.virtual_size as usize;
     let read_size = {
-        let read_size = (section.pointer_to_raw_data as usize + size_of_raw_data + file_alignment
+        let read_size = ((section.pointer_to_raw_data as usize + size_of_raw_data + file_alignment
             - 1)
-            & !(file_alignment - 1);
+            & !(file_alignment - 1)) - aligned_pointer_to_raw_data(section.pointer_to_raw_data as usize);
         cmp::min(read_size, round_size(size_of_raw_data))
     };
 

--- a/src/pe/utils.rs
+++ b/src/pe/utils.rs
@@ -38,11 +38,7 @@ fn section_read_size(section: &section_table::SectionTable, file_alignment: u32)
         cmp::min(read_size, round_size(size_of_raw_data))
     };
 
-    if virtual_size == 0 {
-        read_size
-    } else {
-        cmp::min(read_size, round_size(virtual_size))
-    }
+    cmp::max(read_size, round_size(virtual_size))
 }
 
 fn rva2offset(rva: usize, section: &section_table::SectionTable) -> usize {


### PR DESCRIPTION
See the associated issue (#291) for details.

This PR does the following:

1. Introduce a subtraction that was present in the [stackexchange post](https://reverseengineering.stackexchange.com/questions/4324/reliable-algorithm-to-extract-overlay-of-a-pe) linked in the source
2. Replace the `min` by a `max` so that the section size is at least as big as the virtual size. Note that this deviates from the linked stackexchange post. However, it does fix the associated issue for the tested binaries.

## Tests

Manual tests with the following test driver (using symbolic, that uses goblin):

```toml
# Cargo.toml
[package]
name = "symbolic_symbols"
version = "0.1.0"
edition = "2018"

# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

[dependencies]
symbolic = "*"
anyhow = "1.0"
env_logger = "*"


[patch.crates-io]
goblin = { path = "goblin" }
```

```rust
// src/main.rs
use std::ops::Deref;

use anyhow::Context;
use symbolic::debuginfo::Object;

fn main() -> anyhow::Result<()> {
    env_logger::init();
    let data = std::fs::read(std::env::args_os().nth(1).context("Expected path to binary")?)?;
    let object = Object::parse(data.deref())?;
    for symbol in object.symbols() {
        println!("{}", symbol.name().unwrap());
    }
    Ok(())
}
```

On the two tests binaries: [libxml2.dll](https://github.com/dureuill/goblin/raw/assets/assets/libxml2.dll) and
[VBoxMRXNP.dll](https://github.com/dureuill/goblin/raw/assets/assets/VBoxMRXNP.dll) + [`quine.exe`](https://github.com/corkami/pocs/blob/master/PE/bin/quine.exe) from #101.

Compared with `rabin2 -E $PE`.

1. Before this PR, not the same number of symbols, quine.exe loads successfully (with 0 symbols)
2. After this PR, same number of symbols as rabin2, quine.exe still loads successfully (still with 0 symbols)

Thank you for your time and consideration!