### PR TITLE
Support exports without offset

### DIFF
--- a/src/pe/export.rs
+++ b/src/pe/export.rs
@@ -259,7 +259,7 @@ impl<'a> Reexport<'a> {
 /// An exported symbol in this binary, contains synthetic data (name offset, etc., are computed)
 pub struct Export<'a> {
     pub name: Option<&'a str>,
-    pub offset: usize,
+    pub offset: Option<usize>,
     pub rva: usize,
     pub size: usize,
     pub reexport: Option<Reexport<'a>>,
@@ -301,16 +301,7 @@ impl<'a, 'b> scroll::ctx::TryFromCtx<'a, ExportCtx<'b>> for Export<'a> {
                 match *rva {
                     ExportRVA(rva) => {
                         let rva = rva as usize;
-                        let offset = utils::find_offset_or(
-                            rva,
-                            sections,
-                            file_alignment,
-                            &opts,
-                            &format!(
-                                "cannot map RVA ({:#x}) of export ordinal {} into offset",
-                                rva, ordinal
-                            ),
-                        )?;
+                        let offset = utils::find_offset(rva, sections, file_alignment, &opts);
                         Ok((
                             Export {
                                 name,
@@ -339,7 +330,7 @@ impl<'a, 'b> scroll::ctx::TryFromCtx<'a, ExportCtx<'b>> for Export<'a> {
                         Ok((
                             Export {
                                 name,
-                                offset,
+                                offset: Some(offset),
                                 rva,
                                 reexport: Some(reexport),
                                 size: 0,


### PR DESCRIPTION
This PR is a replacement for #292, which applies the change discussed there: 

- make offset an `Option<_>` in `Export`, and support when an `Export` has no offset.

Moreover, the correct commit of #292 (add missing subtraction) is retained.

## Test

The same procedure as in #292 was followed.
This change does fix the issue #291  and the previously missing symbols are now returned for the tested binaries. 

Thanks again for your time and consideration!