### PR TITLE
Guard every with_capacity call with a bounds check

### DIFF
--- a/src/archive/mod.rs
+++ b/src/archive/mod.rs
@@ -218,8 +218,7 @@ impl<'a> Index<'a> {
         let sizeof_table = buffer.gread_with::<u32>(offset, scroll::BE)? as usize;
 
         if sizeof_table > buffer.len() / 4 {
-            let message = format!("Buffer is too short for {} indices", sizeof_table);
-            return Err(Error::Malformed(message));
+            return Err(Error::BufferTooShort(sizeof_table, "indices"));
         }
 
         let mut indexes = Vec::with_capacity(sizeof_table);
@@ -277,8 +276,7 @@ impl<'a> Index<'a> {
         let strtab = strtab::Strtab::parse(buffer, entries_bytes + 8, strtab_bytes, 0x0)?;
 
         if entries_bytes > buffer.len() {
-            let message = format!("Buffer is too short for {} entries", entries);
-            return Err(Error::Malformed(message));
+            return Err(Error::BufferTooShort(entries, "entries"));
         }
 
         // build the index
@@ -324,8 +322,7 @@ impl<'a> Index<'a> {
         let members = buffer.gread_with::<u32>(offset, scroll::LE)? as usize;
 
         if members > buffer.len() / 4 {
-            let message = format!("Buffer is too short for {} members", members);
-            return Err(Error::Malformed(message));
+            return Err(Error::BufferTooShort(members, "members"));
         }
 
         let mut member_offsets = Vec::with_capacity(members);
@@ -336,8 +333,7 @@ impl<'a> Index<'a> {
         let symbols = buffer.gread_with::<u32>(offset, scroll::LE)? as usize;
 
         if symbols > buffer.len() / 2 {
-            let message = format!("Buffer is too short for {} symbols", symbols);
-            return Err(Error::Malformed(message));
+            return Err(Error::BufferTooShort(symbols, "symbols"));
         }
 
         let mut symbol_offsets = Vec::with_capacity(symbols);

--- a/src/elf/program_header.rs
+++ b/src/elf/program_header.rs
@@ -161,8 +161,7 @@ if_alloc! {
             use scroll::Pread;
             // Sanity check to avoid OOM
             if count > bytes.len() / Self::size(ctx) {
-                let message = format!("Buffer is too short for {} program headers", count);
-                return Err(error::Error::Malformed(message));
+                return Err(error::Error::BufferTooShort(count, "program headers"));
             }
             let mut program_headers = Vec::with_capacity(count);
             for _ in 0..count {

--- a/src/elf/section_header.rs
+++ b/src/elf/section_header.rs
@@ -459,8 +459,7 @@ if_alloc! {
 
             // Sanity check to avoid OOM
             if count > bytes.len() / Self::size(ctx) {
-                let message = format!("Buffer is too short for {} section headers", count);
-                return Err(error::Error::Malformed(message));
+                return Err(error::Error::BufferTooShort(count, "section headers"));
             }
             let mut section_headers = Vec::with_capacity(count);
             section_headers.push(empty_sh);

--- a/src/elf/sym.rs
+++ b/src/elf/sym.rs
@@ -388,6 +388,10 @@ impl Sym {
     #[cfg(feature = "endian_fd")]
     /// Parse `count` vector of ELF symbols from `offset`
     pub fn parse(bytes: &[u8], mut offset: usize, count: usize, ctx: Ctx) -> Result<Vec<Sym>> {
+        if count > bytes.len() / Sym::size_with(&ctx) {
+            let message = format!("Buffer is too short for {} symbols", count);
+            return Err(crate::error::Error::Malformed(message));
+        }
         let mut syms = Vec::with_capacity(count);
         for _ in 0..count {
             let sym = bytes.gread_with(&mut offset, ctx)?;

--- a/src/elf/sym.rs
+++ b/src/elf/sym.rs
@@ -389,8 +389,7 @@ impl Sym {
     /// Parse `count` vector of ELF symbols from `offset`
     pub fn parse(bytes: &[u8], mut offset: usize, count: usize, ctx: Ctx) -> Result<Vec<Sym>> {
         if count > bytes.len() / Sym::size_with(&ctx) {
-            let message = format!("Buffer is too short for {} symbols", count);
-            return Err(crate::error::Error::Malformed(message));
+            return Err(crate::error::Error::BufferTooShort(count, "symbols"));
         }
         let mut syms = Vec::with_capacity(count);
         for _ in 0..count {

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,7 @@ use core::result;
 #[cfg(feature = "std")]
 use std::{error, io};
 
+#[non_exhaustive]
 #[derive(Debug)]
 /// A custom Goblin error
 pub enum Error {
@@ -19,6 +20,8 @@ pub enum Error {
     /// An IO based error
     #[cfg(feature = "std")]
     IO(io::Error),
+    /// Buffer is too short to hold N items
+    BufferTooShort(usize, &'static str),
 }
 
 #[cfg(feature = "std")]
@@ -27,8 +30,7 @@ impl error::Error for Error {
         match *self {
             Error::IO(ref io) => Some(io),
             Error::Scroll(ref scroll) => Some(scroll),
-            Error::BadMagic(_) => None,
-            Error::Malformed(_) => None,
+            _ => None,
         }
     }
 }
@@ -54,6 +56,7 @@ impl fmt::Display for Error {
             Error::Scroll(ref err) => write!(fmt, "{}", err),
             Error::BadMagic(magic) => write!(fmt, "Invalid magic number: 0x{:x}", magic),
             Error::Malformed(ref msg) => write!(fmt, "Malformed entity: {}", msg),
+            Error::BufferTooShort(n, item) => write!(fmt, "Buffer is too short for {} {}", n, item),
         }
     }
 }

--- a/src/mach/exports.rs
+++ b/src/mach/exports.rs
@@ -199,6 +199,10 @@ impl<'a> ExportTrie<'a> {
         current_symbol: String,
         mut offset: usize,
     ) -> error::Result<Vec<(String, usize)>> {
+        if nbranches > self.data.len() {
+            let message = format!("Buffer is too short for {} branches", nbranches);
+            return Err(error::Error::Malformed(message));
+        }
         let mut branches = Vec::with_capacity(nbranches);
         //println!("\t@{:#x}", *offset);
         for _i in 0..nbranches {

--- a/src/mach/exports.rs
+++ b/src/mach/exports.rs
@@ -200,8 +200,7 @@ impl<'a> ExportTrie<'a> {
         mut offset: usize,
     ) -> error::Result<Vec<(String, usize)>> {
         if nbranches > self.data.len() {
-            let message = format!("Buffer is too short for {} branches", nbranches);
-            return Err(error::Error::Malformed(message));
+            return Err(error::Error::BufferTooShort(nbranches, "branches"));
         }
         let mut branches = Vec::with_capacity(nbranches);
         //println!("\t@{:#x}", *offset);

--- a/src/mach/mod.rs
+++ b/src/mach/mod.rs
@@ -166,8 +166,7 @@ impl<'a> MachO<'a> {
         let sizeofcmds = header.sizeofcmds as usize;
         // a load cmd is at least 2 * 4 bytes, (type, sizeof)
         if ncmds > sizeofcmds / 8 || sizeofcmds > bytes.len() {
-            let message = format!("Buffer is too short for {} load commands", ncmds);
-            return Err(error::Error::Malformed(message));
+            return Err(error::Error::BufferTooShort(ncmds, "load commands"));
         }
 
         let mut cmds: Vec<load_command::LoadCommand> = Vec::with_capacity(ncmds);
@@ -373,8 +372,7 @@ impl<'a> MultiArch<'a> {
     /// Return all the architectures in this binary
     pub fn arches(&self) -> error::Result<Vec<fat::FatArch>> {
         if self.narches > self.data.len() / fat::SIZEOF_FAT_ARCH {
-            let message = format!("Buffer is too short for {} arches", self.narches);
-            return Err(error::Error::Malformed(message));
+            return Err(error::Error::BufferTooShort(self.narches, "arches"));
         }
 
         let mut arches = Vec::with_capacity(self.narches);

--- a/src/pe/export.rs
+++ b/src/pe/export.rs
@@ -108,6 +108,21 @@ impl<'a> ExportData<'a> {
         let number_of_name_pointers = export_directory_table.number_of_name_pointers as usize;
         let address_table_entries = export_directory_table.address_table_entries as usize;
 
+        if number_of_name_pointers > bytes.len() {
+            let message = format!(
+                "Buffer is too short for {} name pointers",
+                number_of_name_pointers
+            );
+            return Err(error::Error::Malformed(message));
+        }
+        if address_table_entries > bytes.len() {
+            let message = format!(
+                "Buffer is too short for {} address table entries",
+                address_table_entries
+            );
+            return Err(error::Error::Malformed(message));
+        }
+
         let export_name_pointer_table = utils::find_offset(
             export_directory_table.name_pointer_rva as usize,
             sections,

--- a/src/pe/export.rs
+++ b/src/pe/export.rs
@@ -109,18 +109,16 @@ impl<'a> ExportData<'a> {
         let address_table_entries = export_directory_table.address_table_entries as usize;
 
         if number_of_name_pointers > bytes.len() {
-            let message = format!(
-                "Buffer is too short for {} name pointers",
-                number_of_name_pointers
-            );
-            return Err(error::Error::Malformed(message));
+            return Err(error::Error::BufferTooShort(
+                number_of_name_pointers,
+                "name pointers",
+            ));
         }
         if address_table_entries > bytes.len() {
-            let message = format!(
-                "Buffer is too short for {} address table entries",
-                address_table_entries
-            );
-            return Err(error::Error::Malformed(message));
+            return Err(error::Error::BufferTooShort(
+                address_table_entries,
+                "address table entries",
+            ));
         }
 
         let export_name_pointer_table = utils::find_offset(

--- a/src/pe/header.rs
+++ b/src/pe/header.rs
@@ -147,8 +147,7 @@ impl CoffHeader {
 
         // a section table is at least 40 bytes
         if nsections > bytes.len() / 40 {
-            let message = format!("Buffer is too short for {} sections", nsections);
-            return Err(error::Error::Malformed(message));
+            return Err(error::Error::BufferTooShort(nsections, "sections"));
         }
 
         let mut sections = Vec::with_capacity(nsections);

--- a/tests/macho.rs
+++ b/tests/macho.rs
@@ -577,3 +577,10 @@ fn relocations() {
     assert_eq!(reloc.is_pic(), true);
     assert_eq!(reloc.is_extern(), true);
 }
+
+// See https://github.com/getsentry/symbolic/issues/479
+#[test]
+fn fuzzed_memory_growth() {
+    let bytes = b"\xfe\xed\xfa\xce\xce\xfa\xff\xfe\xcf*\x06;\xfe\xfa\xce\xff\xff\xff\xff0\xce:\xfa\xffj\xfe\xcf*\x06\x00;\xc6";
+    assert!(Mach::parse(&bytes[..]).is_err());
+}


### PR DESCRIPTION
The crate does a lot of pre-allocation based on untrusted input, which
can lead to unbounded allocation.

This came up in https://github.com/getsentry/symbolic/issues/479, and I see the crate already had some bounds checks for certain parts, though not for Mach-O parsing.

I went a bit overboard and added explicit bounds checks for every place where a `with_capacity` is called.