### PR TITLE
elf: Handle SHN_XINDEX for strtab section index (#304)

### DIFF
--- a/src/elf/mod.rs
+++ b/src/elf/mod.rs
@@ -277,7 +277,14 @@ if_sylvan! {
 
             let section_headers = SectionHeader::parse(bytes, header.e_shoff as usize, header.e_shnum as usize, ctx)?;
 
-            let get_strtab = |section_headers: &[SectionHeader], section_idx: usize| {
+            let get_strtab = |section_headers: &[SectionHeader], mut section_idx: usize| {
+                if section_idx == section_header::SHN_XINDEX as usize {
+                    if section_headers.is_empty() {
+                        return Ok(Strtab::default())
+                    }
+                    section_idx = section_headers[0].sh_link as usize;
+                }
+
                 if section_idx >= section_headers.len() {
                     // FIXME: warn! here
                     Ok(Strtab::default())


### PR DESCRIPTION
This attempts to fix #304.  
With this patch, I no longer reproduce the issue using the same large object file that triggered it before.  

I've also updated the test code to handle XINDEX for the strtab, however I don't know a good way to generate a test case for an ELF file with >=2^16 sections without embedding a very large blob, so I've left it for future work.  
(If I've missed a simple way to do this, happy to do it now)