### PR TITLE
Adjust coff symbol offset to account for the strtable length field

### DIFF
--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -343,11 +343,24 @@ mod tests {
     ];
 
     #[test]
-    fn issue_309() {
+    fn string_table_excludes_length() {
         let coff = Coff::parse(&&COFF_FILE_SINGLE_STRING_IN_STRING_TABLE[..]).unwrap();
         let string_table = coff.strings.to_vec().unwrap();
 
         assert!(string_table == vec!["ExitProcess"]);
+    }
+
+    #[test]
+    fn symbol_name_excludes_length() {
+        let coff = Coff::parse(&COFF_FILE_SINGLE_STRING_IN_STRING_TABLE).unwrap();
+        let strings = coff.strings;
+        let symbols = coff
+            .symbols
+            .iter()
+            .filter(|(_, name, _)| name.is_none())
+            .map(|(_, _, sym)| sym.name(&strings).unwrap().to_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(symbols, vec!["ExitProcess"])
     }
 
     #[test]

--- a/src/pe/symbol.rs
+++ b/src/pe/symbol.rs
@@ -231,7 +231,7 @@ impl Symbol {
     /// Returns `None` if the name is inline.
     pub fn name_offset(&self) -> Option<u32> {
         // Symbol offset starts at the strtable's length, so let's adjust it
-        let length_field_size = std::mem::size_of::<u32>() as u32;
+        let length_field_size = core::mem::size_of::<u32>() as u32;
 
         if self.name[0] == 0 {
             self.name

--- a/src/pe/symbol.rs
+++ b/src/pe/symbol.rs
@@ -230,8 +230,14 @@ impl Symbol {
     ///
     /// Returns `None` if the name is inline.
     pub fn name_offset(&self) -> Option<u32> {
+        // Symbol offset starts at the strtable's length, so let's adjust it
+        let length_field_size = std::mem::size_of::<u32>() as u32;
+
         if self.name[0] == 0 {
-            self.name.pread_with(4, scroll::LE).ok()
+            self.name
+                .pread_with(4, scroll::LE)
+                .ok()
+                .map(|offset: u32| offset - length_field_size)
         } else {
             None
         }


### PR DESCRIPTION
I took a crack at #318 myself after attempting to do some investigation. It seems to me that the best place to adjust the offset was here in the pe specific symbol code since `strtab` looks to be at a higher level of abstraction. Apologies if I've missed something important here.