### PR TITLE
elf.dynamic: only consider loadable segments for VM translation

### DIFF
--- a/src/elf/dynamic.rs
+++ b/src/elf/dynamic.rs
@@ -582,7 +582,7 @@ macro_rules! elf_dynamic_info_std_impl {
         /// Convert a virtual memory address to a file offset
         fn vm_to_offset(phdrs: &[$phdr], address: $size) -> Option<$size> {
             for ph in phdrs {
-                if address >= ph.p_vaddr {
+                if ph.p_type == crate::elf::program_header::PT_LOAD && address >= ph.p_vaddr {
                     let offset = address - ph.p_vaddr;
                     if offset < ph.p_memsz {
                         return ph.p_offset.checked_add(offset);


### PR DESCRIPTION
There is little point in using non-loadable segments for the VM address
translation. Ignore non-loadable segments.