### PR TITLE
Fix unbound access to member_offsets in archive/mod.rs:342

### DIFF
--- a/src/archive/mod.rs
+++ b/src/archive/mod.rs
@@ -338,8 +338,13 @@ impl<'a> Index<'a> {
 
         let mut symbol_offsets = Vec::with_capacity(symbols);
         for _ in 0..symbols {
-            symbol_offsets
-                .push(member_offsets[buffer.gread_with::<u16>(offset, scroll::LE)? as usize - 1]);
+            if let Some(symbol_offset) =
+                member_offsets.get(buffer.gread_with::<u16>(offset, scroll::LE)? as usize - 1)
+            {
+                symbol_offsets.push(*symbol_offset);
+            } else {
+                return Err(Error::BufferTooShort(members, "members"));
+            }
         }
         let strtab = strtab::Strtab::parse(buffer, *offset, buffer.len() - *offset, 0x0)?;
         Ok(Index {


### PR DESCRIPTION
Hi!
We were doing some fuzzing with libFuzzer and our tool Sydr and found an unbound access to `member_offsets`:
`thread 'main' panicked at 'index out of bounds: the len is 2 but the index is 3', /goblin/src/archive/mod.rs:342:23`

So, I propose this fix for that.