### PR TITLE
Fix unbound access to bytes slice at  pe/debug.rs:172

### DIFF
--- a/src/pe/debug.rs
+++ b/src/pe/debug.rs
@@ -169,13 +169,18 @@ impl<'a> CodeviewPDB70DebugInfo<'a> {
         let mut signature: [u8; 16] = [0; 16];
         signature.copy_from_slice(bytes.gread_with(&mut offset, 16)?);
         let age: u32 = bytes.gread_with(&mut offset, scroll::LE)?;
-        let filename = &bytes[offset..offset + filename_length];
-
-        Ok(Some(CodeviewPDB70DebugInfo {
-            codeview_signature,
-            signature,
-            age,
-            filename,
-        }))
+        if let Some(filename) = bytes.get(offset..offset + filename_length) {
+            Ok(Some(CodeviewPDB70DebugInfo {
+                codeview_signature,
+                signature,
+                age,
+                filename,
+            }))
+        } else {
+            Err(error::Error::Malformed(format!(
+                "ImageDebugDirectory seems corrupted: {:?}",
+                idd
+            )))
+        }
     }
 }


### PR DESCRIPTION
Hi!
We were doing some fuzzing with Sydr+libFuzzer and found this unbound access to bytes slice at  pe/debug.rs:172. Here is the panic message: `thread '<unnamed>' panicked at 'range end index 16256248 out of range for slice of length 4257', library/core/src/slice/index.rs:73`

I propose this fix.

