### PR TITLE
Fix substract with overflow for header.size

### DIFF
--- a/src/archive/mod.rs
+++ b/src/archive/mod.rs
@@ -132,11 +132,15 @@ impl<'a> Member<'a> {
             )?;
 
             // adjust the offset and size accordingly
-            *offset = header_offset + SIZEOF_HEADER + len;
-            header.size -= len;
+            if header.size > len {
+                *offset = header_offset + SIZEOF_HEADER + len;
+                header.size -= len;
 
-            // the name may have trailing NULs which we don't really want to keep
-            Some(name.trim_end_matches('\0'))
+                // the name may have trailing NULs which we don't really want to keep
+                Some(name.trim_end_matches('\0'))
+            } else {
+                None
+            }
         } else {
             None
         };


### PR DESCRIPTION
Our tool Sydr found an overflow. Here is the input: 
[crash-sydr_1d821e2a398a547fe1aa4a445c8f31d2c51761d6_int_overflow_1_unsigned.txt](https://github.com/m4b/goblin/files/9585735/crash-sydr_1d821e2a398a547fe1aa4a445c8f31d2c51761d6_int_overflow_1_unsigned.txt)
