### PR TITLE
Enable debug info in fuzz targets

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,6 +11,9 @@ cargo-fuzz = true
 [dependencies.goblin]
 path = ".."
 
+[profile.release]
+debug = true
+
 [dependencies.libfuzzer-sys]
 git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
 


### PR DESCRIPTION
This PR adds debug info to fuzz targets in order to see source lines in libFuzzer stack trace.