### PR TITLE
elf.reloc: add workaround for 0-sized relas

### DIFF
--- a/src/elf/reloc.rs
+++ b/src/elf/reloc.rs
@@ -416,9 +416,9 @@ if_alloc! {
         pub fn parse(bytes: &'a [u8], offset: usize, filesz: usize, is_rela: bool, ctx: Ctx) -> crate::error::Result<RelocSection<'a>> {
             // TODO: better error message when too large (see symtab implementation)
             let bytes = if filesz != 0 {
-                bytes.pread_with(offset, filesz)?
+                bytes.pread_with::<&'a [u8]>(offset, filesz)?
             } else {
-                bytes
+                &[]
             };
 
             Ok(RelocSection {

--- a/src/elf/reloc.rs
+++ b/src/elf/reloc.rs
@@ -415,7 +415,11 @@ if_alloc! {
         /// Parse a REL or RELA section of size `filesz` from `offset`.
         pub fn parse(bytes: &'a [u8], offset: usize, filesz: usize, is_rela: bool, ctx: Ctx) -> crate::error::Result<RelocSection<'a>> {
             // TODO: better error message when too large (see symtab implementation)
-            let bytes = bytes.pread_with(offset, filesz)?;
+            let bytes = if filesz != 0 {
+                bytes.pread_with(offset, filesz)?
+            } else {
+                bytes
+            };
 
             Ok(RelocSection {
                 bytes: bytes,


### PR DESCRIPTION
Some ELF files include a .rela section with size 0 instead of simply not including the section. This caused issues with the parser, since bytes.pread_with(offset, filesz) would try and read 0 bytes from a 0-length buffer, which returned an error. This workaround simply swaps out the value with the entire input when filesz is 0; this is the smallest change that appears to work, since count will then be set to 0. This could also be worked around by adding a check in elf.mod (or many other methods), but I thought that it was better to allow the parser to handle 0-sized sections.