### PR TITLE
elf.section_header: additional workaround for 0-length sections

### DIFF
--- a/src/elf/section_header.rs
+++ b/src/elf/section_header.rs
@@ -470,7 +470,7 @@ if_alloc! {
             Ok(section_headers)
         }
         pub fn check_size(&self, size: usize) -> error::Result<()> {
-            if self.sh_type == SHT_NOBITS {
+            if self.sh_type == SHT_NOBITS || self.sh_size == 0 {
                 return Ok(());
             }
             let (end, overflow) = self.sh_offset.overflowing_add(self.sh_size);


### PR DESCRIPTION
One more change necessary for the funky ELFs I have that I forgot to add previously is allowing check_size to immediately return Ok(()) on a 0-sized section, even if that section isn't marked as SHT_NOBITS.