### PR TITLE
pe: fix certificate table parsing

### DIFF
--- a/src/pe/certificate_table.rs
+++ b/src/pe/certificate_table.rs
@@ -139,7 +139,7 @@ pub(crate) fn enumerate_certificates(
     let mut attrs = vec![];
 
     // End offset cannot be further than the binary we have at hand.
-    if table_end_offset >= bytes.len() {
+    if table_end_offset > bytes.len() {
         return Err(error::Error::Malformed(
             "End of attribute certificates table is after the end of the PE binary".to_string(),
         ));


### PR DESCRIPTION
There appear to be an off-by-one error in the parsing of the certificate table. This error would occur when the cert table is at the end of the binary.

cc @RaitoBezarius 