### PR TITLE
Fix `is_lib` detection for PIE and static PIE Elf objects.

### DIFF
--- a/src/elf/mod.rs
+++ b/src/elf/mod.rs
@@ -383,7 +383,7 @@ if_sylvan! {
             let verdef = symver::VerdefSection::parse(bytes, &section_headers, ctx)?;
             let verneed = symver::VerneedSection::parse(bytes, &section_headers, ctx)?;
 
-            let is_lib = misc.is_lib && (!is_pie) && interpreter.is_none();
+            let is_lib = misc.is_lib && !is_pie;
 
             Ok(Elf {
                 header,

--- a/src/elf/mod.rs
+++ b/src/elf/mod.rs
@@ -321,8 +321,7 @@ if_sylvan! {
             if let Some(ref dynamic) = dynamic {
                 let dyn_info = &dynamic.info;
 
-                is_pie = misc.is_lib && dyn_info.flags_1 != 0;
-
+                is_pie = dyn_info.flags_1 & dynamic::DF_1_PIE != 0;
                 dynstrtab = Strtab::parse(bytes,
                                           dyn_info.strtab,
                                           dyn_info.strsz,

--- a/src/elf/mod.rs
+++ b/src/elf/mod.rs
@@ -307,6 +307,7 @@ if_sylvan! {
                 strtab = get_strtab(&section_headers, shdr.sh_link as usize)?;
             }
 
+            let mut is_pie = false;
             let mut soname = None;
             let mut libraries = vec![];
             let mut rpaths = vec![];
@@ -319,6 +320,9 @@ if_sylvan! {
             let dynamic = Dynamic::parse(bytes, &program_headers, ctx)?;
             if let Some(ref dynamic) = dynamic {
                 let dyn_info = &dynamic.info;
+
+                is_pie = misc.is_lib && dyn_info.flags_1 != 0;
+
                 dynstrtab = Strtab::parse(bytes,
                                           dyn_info.strtab,
                                           dyn_info.strsz,
@@ -379,6 +383,8 @@ if_sylvan! {
             let verdef = symver::VerdefSection::parse(bytes, &section_headers, ctx)?;
             let verneed = symver::VerneedSection::parse(bytes, &section_headers, ctx)?;
 
+            let is_lib = misc.is_lib && (!is_pie) && interpreter.is_none();
+
             Ok(Elf {
                 header,
                 program_headers,
@@ -399,7 +405,7 @@ if_sylvan! {
                 rpaths,
                 runpaths,
                 is_64: misc.is_64,
-                is_lib: misc.is_lib,
+                is_lib,
                 entry: misc.entry,
                 little_endian: misc.little_endian,
                 ctx: ctx,


### PR DESCRIPTION
PIE executables (either static or dynamically linked) erroneously report `is_lib == true`, due to the fact that they have `e_type == ET_DYN` in their elf headers. 

To distinguish you have to check if the DT_FLAGS_1 was set in the dynamics section. 

The part that I'm not sure about is `lazy_parse`, which can't detect if something is a library or not. 