### PR TITLE
Add `ParseOptions` field to toggle parsing Attribute Certificates for PEs loaded into memory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ mach64 = ["alloc", "endian_fd", "archive"]
 pe32 = ["alloc", "endian_fd"]
 pe64 = ["alloc", "endian_fd"]
 archive = ["alloc"]
-in_memory = []
 
 [badges.travis-ci]
 branch = "master"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ mach64 = ["alloc", "endian_fd", "archive"]
 pe32 = ["alloc", "endian_fd"]
 pe64 = ["alloc", "endian_fd"]
 archive = ["alloc"]
+in_memory = []
 
 [badges.travis-ci]
 branch = "master"

--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -212,6 +212,7 @@ impl<'a> PE<'a> {
                 if let Some(exception_table) =
                     *optional_header.data_directories.get_exception_table()
                 {
+                    debug!("about to parse exception data");
                     exception_data = Some(exception::ExceptionData::parse_with_opts(
                         bytes,
                         exception_table,
@@ -219,21 +220,30 @@ impl<'a> PE<'a> {
                         file_alignment,
                         opts,
                     )?);
+                    debug!("successfully parsed exception data");
+                } else {
+                    debug!("exception_table is None, skipping attempt to parse exception data");
                 }
             }
 
-            let certtable = if let Some(certificate_table) =
-                *optional_header.data_directories.get_certificate_table()
-            {
-                certificates = certificate_table::enumerate_certificates(
-                    bytes,
-                    certificate_table.virtual_address,
-                    certificate_table.size,
-                )?;
+            let certtable = if opts.parse_attribute_certificates {
+                if let Some(certificate_table) =
+                    *optional_header.data_directories.get_certificate_table()
+                {
+                    debug!("about to enumerate_certificates");
+                    certificates = certificate_table::enumerate_certificates(
+                        bytes,
+                        certificate_table.virtual_address,
+                        certificate_table.size,
+                    )?;
+                    debug!("successfully enumerated certificates");
 
-                let start = certificate_table.virtual_address as usize;
-                let end = start + certificate_table.size as usize;
-                Some(start..end)
+                    let start = certificate_table.virtual_address as usize;
+                    let end = start + certificate_table.size as usize;
+                    Some(start..end)
+                } else {
+                    None
+                }
             } else {
                 None
             };

--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -228,11 +228,7 @@ impl<'a> PE<'a> {
 
             // Parse attribute certificates unless opted out of via
             // the in_memory feature and the parse_attribute_certificates parsing option.
-            #[cfg(feature = "in_memory")]
-            let parse_attribute_certificates = opts.parse_attribute_certificates;
-            #[cfg(not(feature = "in_memory"))]
-            let parse_attribute_certificates = true;
-            let certtable = if parse_attribute_certificates {
+            let certtable = if opts.parse_attribute_certificates {
                 if let Some(certificate_table) =
                     *optional_header.data_directories.get_certificate_table()
                 {

--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -222,8 +222,7 @@ impl<'a> PE<'a> {
                 }
             }
 
-            // Parse attribute certificates unless opted out of via
-            // the in_memory feature and the parse_attribute_certificates parsing option.
+            // Parse attribute certificates unless opted out of
             let certtable = if opts.parse_attribute_certificates {
                 if let Some(certificate_table) =
                     *optional_header.data_directories.get_certificate_table()

--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -226,7 +226,13 @@ impl<'a> PE<'a> {
                 }
             }
 
-            let certtable = if opts.parse_attribute_certificates {
+            // Parse attribute certificates unless opted out of via
+            // the in_memory feature and the parse_attribute_certificates parsing option.
+            #[cfg(feature = "in_memory")]
+            let parse_attribute_certificates = opts.parse_attribute_certificates;
+            #[cfg(not(feature = "in_memory"))]
+            let parse_attribute_certificates = true;
+            let certtable = if parse_attribute_certificates {
                 if let Some(certificate_table) =
                     *optional_header.data_directories.get_certificate_table()
                 {

--- a/src/pe/options.rs
+++ b/src/pe/options.rs
@@ -3,11 +3,22 @@
 pub struct ParseOptions {
     /// Wether the parser should resolve rvas or not. Default: true
     pub resolve_rva: bool,
+    /// Whether or not to parse attribute certificates.
+    /// Set to false for in-memory representation, as the [loader does not map this info into
+    /// memory](https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#other-contents-of-the-file).
+    /// For on-disk representations, leave as true.
+    /// Default: true
+    #[cfg(feature = "in_memory")]
+    pub parse_attribute_certificates: bool,
 }
 
 impl ParseOptions {
     /// Returns a parse options structure with default values
     pub fn default() -> Self {
-        ParseOptions { resolve_rva: true }
+        ParseOptions {
+            resolve_rva: true,
+            #[cfg(feature = "in_memory")]
+            parse_attribute_certificates: true,
+        }
     }
 }

--- a/src/pe/options.rs
+++ b/src/pe/options.rs
@@ -6,9 +6,7 @@ pub struct ParseOptions {
     /// Whether or not to parse attribute certificates.
     /// Set to false for in-memory representation, as the [loader does not map this info into
     /// memory](https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#other-contents-of-the-file).
-    /// For on-disk representations, leave as true.
-    /// Default: true
-    #[cfg(feature = "in_memory")]
+    /// For on-disk representations, leave as true. Default: true
     pub parse_attribute_certificates: bool,
 }
 
@@ -17,7 +15,6 @@ impl ParseOptions {
     pub fn default() -> Self {
         ParseOptions {
             resolve_rva: true,
-            #[cfg(feature = "in_memory")]
             parse_attribute_certificates: true,
         }
     }


### PR DESCRIPTION
Per [this documentation](https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#other-contents-of-the-file) (just above "Section Data"), the attribute certificate table is not loaded into memory along with the rest of the PE. This PR fixes #376 by adding a `ParseOptions` field that allows a user to skip parsing the attribute certificate table altogether, making parsing of loaded PEs possible.