### PR TITLE
pe: Attribute certificate revisions are non-exhaustive

### DIFF
--- a/src/pe/certificate_table.rs
+++ b/src/pe/certificate_table.rs
@@ -9,6 +9,7 @@ use alloc::string::ToString;
 use alloc::vec::Vec;
 
 #[repr(u16)]
+#[non_exhaustive]
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum AttributeCertificateRevision {
     /// WIN_CERT_REVISION_1_0


### PR DESCRIPTION
Excerpt of https://learn.microsoft.com/en-us/windows/win32/debug/pe-format

> The options for the WIN_CERTIFICATE wRevision member
> include *(but are not limited to)* the following.

Emphasis mine.