### PR TITLE
elf: Add convenient functions for symbol write

### DIFF
--- a/src/elf/sym.rs
+++ b/src/elf/sym.rs
@@ -541,6 +541,18 @@ if_alloc! {
             self.count
         }
 
+        /// The offset of symbol table in elf
+        #[inline]
+        pub fn offset(&self) -> usize {
+            self.start
+        }
+
+        /// The ctx of symbol table
+        #[inline]
+        pub fn ctx(&self) -> &Ctx {
+            &self.ctx
+        }
+
         /// Returns true if table has no symbols.
         #[inline]
         pub fn is_empty(&self) -> bool {


### PR DESCRIPTION
Here is an example of modifying elf:

```rust
use goblin::elf::{section_header, sym::Sym, Elf};
use scroll::{ctx::SizeWith, Pwrite};

use anyhow::Result;
use std::fs;

fn main() -> Result<()> {
    let path = "my.elf";
    let mut buffer = fs::read(path)?;
    let elf = Elf::parse(&buffer)?;

    let ctx = elf.syms.ctx().clone();
    for (index, mut sym) in elf.syms.iter().enumerate() {
        let Some(name) = elf.strtab.get_at(sym.st_name) else {
            continue;
        };

        if name == "my_symbol" {
            let offset = elf.syms.offset() + index * Sym::size_with(elf.syms.ctx());
            println!("name: {}, offset: {}", name, offset);
            sym.st_shndx = section_header::SHN_ABS as usize;
            sym.st_value = 0xeaeaeaea;
            buffer.pwrite_with(sym, offset, ctx)?;
            break;
        }
    }

    Ok(())
}

```

https://github.com/m4b/goblin/issues/325#issuecomment-1288407913 shows that we can modify elf, but we can't get the underlying offset and the symbol size.

Although we can iterate the section header and find the offset, it is not so convenient, this PR exposes some useful field to make it easier.