### PR TITLE
fix doc warnings

### DIFF
--- a/src/elf/constants_relocation.rs
+++ b/src/elf/constants_relocation.rs
@@ -498,7 +498,7 @@ pub const R_ARM_GOT32: u32 = 26;
 pub const R_ARM_PLT32: u32 = 27;
 /// PC relative 24 bit (BL, BLX)
 pub const R_ARM_CALL: u32 = 28;
-/// PC relative 24 bit (B, BL<cond>)
+/// PC relative 24 bit (B, BL&lt;cond&gt;)
 pub const R_ARM_JUMP24: u32 = 29;
 /// PC relative 24 bit (Thumb32 B.W)
 pub const R_ARM_THM_JUMP24: u32 = 30;
@@ -539,7 +539,7 @@ pub const R_ARM_THM_MOVT_ABS: u32 = 48;
 pub const R_ARM_THM_MOVW_PREL_NC: u32 = 49;
 /// PC relative high 16 bit (Thumb32 MOVT)
 pub const R_ARM_THM_MOVT_PREL: u32 = 50;
-/// PC relative 20 bit (Thumb32 B<cond>.W)
+/// PC relative 20 bit (Thumb32 B&lt;cond&gt;.W)
 pub const R_ARM_THM_JUMP19: u32 = 51;
 /// PC relative X & 0x7E (Thumb16 CBZ, CBNZ)
 pub const R_ARM_THM_JUMP6: u32 = 52;
@@ -636,7 +636,7 @@ pub const R_ARM_GNU_VTENTRY: u32 = 100;
 pub const R_ARM_GNU_VTINHERIT: u32 = 101;
 /// PC relative & 0xFFE (Thumb16 B)
 pub const R_ARM_THM_PC11: u32 = 102;
-/// PC relative & 0x1FE (Thumb16 B/B<cond>)
+/// PC relative & 0x1FE (Thumb16 B/B&lt;cond&gt;)
 pub const R_ARM_THM_PC9: u32 = 103;
 /// PC-rel 32 bit for global dynamic thread local data
 pub const R_ARM_TLS_GD32: u32 = 104;

--- a/src/elf/dynamic.rs
+++ b/src/elf/dynamic.rs
@@ -550,7 +550,7 @@ macro_rules! elf_dyn_std_impl {
             }
 
             // TODO: these bare functions have always seemed awkward, but not sure where they should go...
-            /// Maybe gets and returns the dynamic array with the same lifetime as the [phdrs], using the provided bias with wrapping addition.
+            /// Maybe gets and returns the dynamic array with the same lifetime as the `phdrs`, using the provided bias with wrapping addition.
             /// If the bias is wrong, it will either segfault or give you incorrect values, beware
             pub unsafe fn from_phdrs(bias: usize, phdrs: &[$phdr]) -> Option<&[Dyn]> {
                 for phdr in phdrs {

--- a/src/elf/gnu_hash.rs
+++ b/src/elf/gnu_hash.rs
@@ -13,9 +13,9 @@
 //!  4. shift2
 //!
 //! See more:
-//!  * http://www.linker-aliens.org/blogs/ali/entry/gnu_hash_elf_sections
-//!    or https://blogs.oracle.com/solaris/gnu-hash-elf-sections-v2
-//!  * https://flapenguin.me/2017/05/10/elf-lookup-dt-gnu-hash/
+//!  * <http://www.linker-aliens.org/blogs/ali/entry/gnu_hash_elf_sections>
+//!    or <https://blogs.oracle.com/solaris/gnu-hash-elf-sections-v2>
+//!  * <https://flapenguin.me/2017/05/10/elf-lookup-dt-gnu-hash/>
 
 /// GNU hash function: accepts a symbol name and returns a value that may be
 /// used to compute a bucket index.

--- a/src/elf/reloc.rs
+++ b/src/elf/reloc.rs
@@ -56,14 +56,14 @@
 //! | `R_X86_64_TLSDESC`        | 36    | 64 × 2    |                   |
 //! | `R_X86_64_IRELATIVE`      | 37    | 64        | indirect (B + A)  |
 //!
-//! TLS information is at http://people.redhat.com/aoliva/writeups/TLS/RFC-TLSDESC-x86.txt
+//! TLS information is at <http://people.redhat.com/aoliva/writeups/TLS/RFC-TLSDESC-x86.txt>
 //!
 //! `R_X86_64_IRELATIVE` is similar to `R_X86_64_RELATIVE` except that
 //! the value used in this relocation is the program address returned by the function,
 //! which takes no arguments, at the address of the result of the corresponding
 //! `R_X86_64_RELATIVE` relocation.
 //!
-//! Read more https://docs.oracle.com/cd/E23824_01/html/819-0690/chapter6-54839.html
+//! Read more <https://docs.oracle.com/cd/E23824_01/html/819-0690/chapter6-54839.html>
 
 include!("constants_relocation.rs");
 

--- a/src/pe/authenticode.rs
+++ b/src/pe/authenticode.rs
@@ -17,8 +17,7 @@ use super::{section_table::SectionTable, PE};
 static PADDING: [u8; 7] = [0; 7];
 
 impl PE<'_> {
-    /// [`authenticode_ranges`] returns the various ranges of the binary that are relevant for
-    /// signature.
+    /// Returns the various ranges of the binary that are relevant for signature.
     pub fn authenticode_ranges(&self) -> ExcludedSectionsIter<'_> {
         ExcludedSectionsIter {
             pe: self,

--- a/src/pe/exception.rs
+++ b/src/pe/exception.rs
@@ -612,7 +612,7 @@ impl<'a> UnwindInfo<'a> {
     /// Returns an iterator over unwind codes in this unwind info.
     ///
     /// Unwind codes are iterated in descending `code_offset` order suitable for unwinding. If the
-    /// optional [`chained_info`] is present, codes of that unwind info should be interpreted
+    /// optional [`chained_info`](Self::chained_info) is present, codes of that unwind info should be interpreted
     /// immediately afterwards.
     pub fn unwind_codes(&self) -> UnwindCodeIterator<'a> {
         UnwindCodeIterator {

--- a/src/strtab.rs
+++ b/src/strtab.rs
@@ -29,7 +29,7 @@ impl<'a> Strtab<'a> {
     /// Creates a `Strtab` with `bytes` as the backing string table, using `delim` as the delimiter between entries.
     ///
     /// NB: this does *not* preparse the string table, which can have non-optimal access patterns.
-    /// See https://github.com/m4b/goblin/pull/275#issue-660364025
+    /// See <https://github.com/m4b/goblin/pull/275>
     pub fn new(bytes: &'a [u8], delim: u8) -> Self {
         Self::from_slice_unparsed(bytes, 0, bytes.len(), delim)
     }


### PR DESCRIPTION
All of these were reported by `cargo doc`. (This should probably have a CI job set up to fail on warnings).

For the authenticode change, I figured it wasn't really that important to link to the method that the doc is *on*, so I just deleted that. And for the strtab change, the anchor hash at the end of the url didn't seem to *link* anywhere relevant?