### PR TITLE
Nearly fully documented the optional PE header.

### DIFF
--- a/src/pe/characteristic.rs
+++ b/src/pe/characteristic.rs
@@ -1,3 +1,6 @@
+//! Constants for flags that indicate attributes of the object or image file. These flags are used in the
+//! [`goblin::pe::header::CoffHeader::characteristics`](crate::pe::header::CoffHeader::characteristics) field.
+
 /*
 type characteristic =
     | IMAGE_FILE_RELOCS_STRIPPED
@@ -73,27 +76,65 @@ let show_type characteristics =
   else "MANY"                   (* print all *)
  */
 
+/// Image only, Windows CE, and Microsoft Windows NT and later. This indicates that the file does not
+/// contain base relocations and must therefore be loaded at its preferred base address. If the base address
+/// is not available, the loader reports an error. The default behavior of the linker is to strip base relocations
+/// from executable (EXE) files.
 pub const IMAGE_FILE_RELOCS_STRIPPED: u16 = 0x0001;
+
+/// Image only. This indicates that the image file is valid and can be run.
+/// If this flag is not set, it indicates a linker error.
 pub const IMAGE_FILE_EXECUTABLE_IMAGE: u16 = 0x0002;
+
+/// COFF line numbers have been removed. This flag is deprecated and should be zero.
 pub const IMAGE_FILE_LINE_NUMS_STRIPPED: u16 = 0x0004;
+
+/// COFF symbol table entries for local symbols have been removed. This flag is deprecated and should be zero.
 pub const IMAGE_FILE_LOCAL_SYMS_STRIPPED: u16 = 0x0008;
+
+/// Obsolete. Aggressively trim working set. This flag is deprecated for Windows 2000 and later and must be zero.
 pub const IMAGE_FILE_AGGRESSIVE_WS_TRIM: u16 = 0x0010;
+
+/// Application can handle > 2-GB addresses.
 pub const IMAGE_FILE_LARGE_ADDRESS_AWARE: u16 = 0x0020;
+
+/// This flag is reserved for future use.
 pub const RESERVED: u16 = 0x0040;
+
+/// Little endian: the least significant bit (LSB) precedes the most significant bit (MSB) in memory.
+/// This flag is deprecated and should be zero.
 pub const IMAGE_FILE_BYTES_REVERSED_LO: u16 = 0x0080;
+
+/// Machine is based on a 32-bit-word architecture.
 pub const IMAGE_FILE_32BIT_MACHINE: u16 = 0x0100;
+
+/// Debugging information is removed from the image file.
 pub const IMAGE_FILE_DEBUG_STRIPPED: u16 = 0x0200;
+
+/// If the image is on removable media, fully load it and copy it to the swap file.
 pub const IMAGE_FILE_REMOVABLE_RUN_FROM_SWAP: u16 = 0x0400;
+
+/// If the image is on network media, fully load it and copy it to the swap file.
 pub const IMAGE_FILE_NET_RUN_FROM_SWAP: u16 = 0x0800;
+
+/// The image file is a system file, not a user program.
 pub const IMAGE_FILE_SYSTEM: u16 = 0x1000;
+
+/// The image file is a dynamic-link library (DLL). Such files are considered executable files for almost all purposes, although they cannot be directly run.
 pub const IMAGE_FILE_DLL: u16 = 0x2000;
+
+/// The file should be run only on a uniprocessor machine.
 pub const IMAGE_FILE_UP_SYSTEM_ONLY: u16 = 0x4000;
+
+/// Big endian: the MSB precedes the LSB in memory. This flag is deprecated and should be zero.
 pub const IMAGE_FILE_BYTES_REVERSED_HI: u16 = 0x8000;
 
+/// Checks whether the characteristics value indicates that the file is a DLL (dynamically-linked library).
 pub fn is_dll(characteristics: u16) -> bool {
     characteristics & IMAGE_FILE_DLL == IMAGE_FILE_DLL
 }
 
+/// Checks whether the characteristics value indicates that the file is an executable.
 pub fn is_exe(characteristics: u16) -> bool {
     characteristics & IMAGE_FILE_EXECUTABLE_IMAGE == IMAGE_FILE_EXECUTABLE_IMAGE
 }

--- a/src/pe/dll_characteristic.rs
+++ b/src/pe/dll_characteristic.rs
@@ -1,0 +1,38 @@
+//! Constants for characteristics of image files. These constants are used in the
+//! [`goblin::pe::optional_header::WindowsFields::dll_characteristics`](crate::pe::optional_header::WindowsFields::dll_characteristics)
+//! field.
+//!
+//! The values 0x0001, 0x0002, 0x0004, 0x0008 are reserved for future use and must be zero.
+
+/// Image can handle a high entropy 64-bit virtual address space.
+pub const IMAGE_DLLCHARACTERISTICS_HIGH_ENTROPY_VA: u16 = 0x0020;
+
+/// DLL can be relocated at load time.
+pub const IMAGE_DLLCHARACTERISTICS_DYNAMIC_BASE: u16 = 0x0040;
+
+/// Code Integrity checks are enforced.
+pub const IMAGE_DLLCHARACTERISTICS_FORCE_INTEGRITY: u16 = 0x0080;
+
+/// Image is NX compatible.
+pub const IMAGE_DLLCHARACTERISTICS_NX_COMPAT: u16 = 0x0100;
+
+/// Isolation aware, but do not isolate the image.
+pub const IMAGE_DLLCHARACTERISTICS_NO_ISOLATION: u16 = 0x0200;
+
+/// Does not use structured exception (SE) handling. No SE handler may be called in this image.
+pub const IMAGE_DLLCHARACTERISTICS_NO_SEH: u16 = 0x0400;
+
+/// Do not bind the image.
+pub const IMAGE_DLLCHARACTERISTICS_NO_BIND: u16 = 0x0800;
+
+/// Image must execute in an AppContainer.
+pub const IMAGE_DLLCHARACTERISTICS_APPCONTAINER: u16 = 0x1000;
+
+/// A WDM driver.
+pub const IMAGE_DLLCHARACTERISTICS_WDM_DRIVER: u16 = 0x2000;
+
+/// Image supports Control Flow Guard.
+pub const IMAGE_DLLCHARACTERISTICS_GUARD_CF: u16 = 0x4000;
+
+/// Terminal Server aware.
+pub const IMAGE_DLLCHARACTERISTICS_TERMINAL_SERVER_AWARE: u16 = 0x8000;

--- a/src/pe/header.rs
+++ b/src/pe/header.rs
@@ -497,7 +497,8 @@ pub struct CoffHeader {
     #[doc(alias("SizeOfOptionalHeader"))]
     pub size_of_optional_header: u16,
     /// The [characteristics](https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#characteristics) of the image.
-    // TODO: add characteristics constants (https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#characteristics)
+    ///
+    /// The constants for the characteristics are available in the [`goblin::pe::characteristic`](crate::pe::characteristic) module.
     #[doc(alias("Characteristics"))]
     pub characteristics: u16,
 }

--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -15,6 +15,7 @@ pub mod certificate_table;
 pub mod characteristic;
 pub mod data_directories;
 pub mod debug;
+pub mod dll_characteristic;
 pub mod exception;
 pub mod export;
 pub mod header;
@@ -23,6 +24,7 @@ pub mod optional_header;
 pub mod options;
 pub mod relocation;
 pub mod section_table;
+pub mod subsystem;
 pub mod symbol;
 pub mod utils;
 

--- a/src/pe/optional_header.rs
+++ b/src/pe/optional_header.rs
@@ -52,6 +52,7 @@ pub struct StandardFields {
     pub address_of_entry_point: u64,
     pub base_of_code: u64,
     /// absent in 64-bit PE32+
+    // Q (JohnScience): Why is this a u32 and not an Option<u32>?
     pub base_of_data: u32,
 }
 
@@ -299,7 +300,18 @@ impl TryFrom<WindowsFields64> for WindowsFields32 {
 
 pub type WindowsFields = WindowsFields64;
 
+/// Either 32 or 64-bit optional header.
+///
+/// Whether it's 32 or 64-bit is determined by the `magic` field and the value of
+/// [`CoffHeader::size_of_optional_header`](crate::pe::header::CoffHeader::size_of_optional_header).
+///
+/// ## Position in PE binary
+///
+/// The optional header is located after [`CoffHeader`](crate::pe::header::CoffHeader) and before
+/// section table.
 #[derive(Debug, PartialEq, Copy, Clone)]
+#[doc(alias = "IMAGE_OPTIONAL_HEADER32")]
+#[doc(alias = "IMAGE_OPTIONAL_HEADER64")]
 pub struct OptionalHeader {
     pub standard_fields: StandardFields,
     pub windows_fields: WindowsFields,

--- a/src/pe/optional_header.rs
+++ b/src/pe/optional_header.rs
@@ -1,3 +1,5 @@
+//! The module for the PE optional header ([`OptionalHeader`]) and related items.
+
 use crate::container;
 use crate::error;
 
@@ -35,6 +37,7 @@ pub struct StandardFields32 {
     pub base_of_data: u32,
 }
 
+/// Convenience constant for `core::mem::size_of::<StandardFields32>()`.
 pub const SIZEOF_STANDARD_FIELDS_32: usize = 28;
 
 /// Standard 64-bit COFF fields (for `PE32+`).
@@ -64,17 +67,25 @@ pub struct StandardFields64 {
     pub base_of_code: u32,
 }
 
+/// Convenience constant for `core::mem::size_of::<StandardFields64>()`.
 pub const SIZEOF_STANDARD_FIELDS_64: usize = 24;
 
-/// Unified 32/64-bit COFF fields (for `PE32` and `PE32+`).
+/// Unified 32/64-bit standard COFF fields (for `PE32` and `PE32+`).
 ///
 /// Notably, a value of this type is a member of
 /// [`goblin::pe::optional_header::OptionalHeader`](crate::pe::optional_header::OptionalHeader),
-/// which represents either
+/// which in turn represents either
 /// * [`IMAGE_OPTIONAL_HEADER32`](https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-image_optional_header32); or
 /// * [`IMAGE_OPTIONAL_HEADER64`](https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-image_optional_header64)
 ///
 /// from `winnt.h`, depending on the value of [`StandardFields::magic`].
+///
+/// ## Position in PE binary
+///
+/// Standard COFF fields are located at the beginning of the [`OptionalHeader`] and before the
+/// [`WindowsFields`].
+///
+/// ## Related structures
 ///
 /// * For 32-bit version, see [`StandardFields32`].
 /// * For 64-bit version, see [`StandardFields64`].
@@ -93,13 +104,13 @@ pub struct StandardFields {
     /// The minor version number of the linker.
     #[doc(alias = "MinorLinkerVersion")]
     pub minor_linker_version: u8,
-    /// The size of the code section, in bytes, or the sum of all such sections if there are multiple code sections.
+    /// The size of the code section (.text), in bytes, or the sum of all such sections if there are multiple code sections.
     #[doc(alias = "SizeOfCode")]
     pub size_of_code: u64,
-    /// The size of the initialized data section, in bytes, or the sum of all such sections if there are multiple initialized data sections.
+    /// The size of the initialized data section (.data), in bytes, or the sum of all such sections if there are multiple initialized data sections.
     #[doc(alias = "SizeOfInitializedData")]
     pub size_of_initialized_data: u64,
-    /// The size of the uninitialized data section, in bytes, or the sum of all such sections if there are multiple uninitialized data sections.
+    /// The size of the uninitialized data section (.bss), in bytes, or the sum of all such sections if there are multiple uninitialized data sections.
     #[doc(alias = "SizeOfUninitializedData")]
     pub size_of_uninitialized_data: u64,
     /// A pointer to the entry point function, relative to the image base address.
@@ -109,9 +120,12 @@ pub struct StandardFields {
     ///
     /// The entry point function is optional for DLLs. When no entry point is present, this member is zero.
     pub address_of_entry_point: u64,
-    /// A pointer to the beginning of the code section, relative to the image base.
+    /// A pointer to the beginning of the code section (.text), relative to the image base.
     pub base_of_code: u64,
-    /// A pointer to the beginning of the data section, relative to the image base. Absent in 64-bit PE32+
+    /// A pointer to the beginning of the data section (.data), relative to the image base. Absent in 64-bit PE32+.
+    ///
+    /// In other words, it is a Relative virtual address (RVA) of the start of the data (.data) section when the PE
+    /// is loaded into memory.
     // Q (JohnScience): Why is this a u32 and not an Option<u32>?
     pub base_of_data: u32,
 }
@@ -179,71 +193,217 @@ impl From<StandardFields> for StandardFields64 {
     }
 }
 
-/// Standard fields magic number for 32-bit binary
+/// Standard fields magic number for 32-bit binary (`PE32`).
 pub const MAGIC_32: u16 = 0x10b;
-/// Standard fields magic number for 64-bit binary
+/// Standard fields magic number for 64-bit binary (`PE32+`).
 pub const MAGIC_64: u16 = 0x20b;
 
-/// Windows specific fields
+/// Windows specific fields for 32-bit binary (`PE32`). They're also known as "NT additional fields".
+///
+/// In `winnt.h`, this is a subset of [`IMAGE_OPTIONAL_HEADER32`](https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-image_optional_header32).
+///
+/// * For 64-bit version, see [`WindowsFields64`].
+/// * For unified version, see [`WindowsFields`].
 #[repr(C)]
 #[derive(Debug, PartialEq, Copy, Clone, Default, Pread, Pwrite, SizeWith)]
 pub struct WindowsFields32 {
+    /// See docs for [`WindowsFields::image_base`].
     pub image_base: u32,
+    /// See docs for [`WindowsFields::section_alignment`].
     pub section_alignment: u32,
+    /// See docs for [`WindowsFields::file_alignment`].
     pub file_alignment: u32,
+    /// See docs for [`WindowsFields::major_operating_system_version`].
     pub major_operating_system_version: u16,
+    /// See docs for [`WindowsFields::minor_operating_system_version`].
     pub minor_operating_system_version: u16,
+    /// See docs for [`WindowsFields::major_image_version`].
     pub major_image_version: u16,
+    /// See docs for [`WindowsFields::minor_image_version`].
     pub minor_image_version: u16,
+    /// See docs for [`WindowsFields::major_subsystem_version`].
     pub major_subsystem_version: u16,
+    /// See docs for [`WindowsFields::minor_subsystem_version`].
     pub minor_subsystem_version: u16,
+    /// See docs for [`WindowsFields::win32_version_value`].
     pub win32_version_value: u32,
+    /// See docs for [`WindowsFields::size_of_image`].
     pub size_of_image: u32,
+    /// See docs for [`WindowsFields::size_of_headers`].
     pub size_of_headers: u32,
+    /// See docs for [`WindowsFields::check_sum`].
     pub check_sum: u32,
+    /// See docs for [`WindowsFields::subsystem`].
     pub subsystem: u16,
+    /// See docs for [`WindowsFields::dll_characteristics`].
     pub dll_characteristics: u16,
+    /// See docs for [`WindowsFields::size_of_stack_reserve`].
     pub size_of_stack_reserve: u32,
+    /// See docs for [`WindowsFields::size_of_stack_commit`].
     pub size_of_stack_commit: u32,
+    /// See docs for [`WindowsFields::size_of_heap_reserve`].
     pub size_of_heap_reserve: u32,
+    /// See docs for [`WindowsFields::size_of_heap_commit`].
     pub size_of_heap_commit: u32,
+    /// See docs for [`WindowsFields::loader_flags`].
     pub loader_flags: u32,
+    /// See docs for [`WindowsFields::number_of_rva_and_sizes`].
     pub number_of_rva_and_sizes: u32,
 }
 
+/// Convenience constant for `core::mem::size_of::<WindowsFields32>()`.
 pub const SIZEOF_WINDOWS_FIELDS_32: usize = 68;
-/// Offset of the `check_sum` field in [`WindowsFields32`]
+/// Offset of the `check_sum` field in [`WindowsFields32`].
 pub const OFFSET_WINDOWS_FIELDS_32_CHECKSUM: usize = 36;
 
-/// 64-bit Windows specific fields
+/// Windows specific fields for 64-bit binary (`PE32+`). They're also known as "NT additional fields".
+///
+/// In `winnt.h`, this is a subset of [`IMAGE_OPTIONAL_HEADER64`](https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-image_optional_header64).
+///
+/// *Note: at the moment of writing, [`WindowsFields`] is an alias for `WindowsFields64`. Though [nominally equivalent](https://en.wikipedia.org/wiki/Nominal_type_system),
+/// they're semantically distinct.*
+///
+/// * For 32-bit version, see [`WindowsFields32`].
+/// * For unified version, see [`WindowsFields`].
 #[repr(C)]
 #[derive(Debug, PartialEq, Copy, Clone, Default, Pread, Pwrite, SizeWith)]
 pub struct WindowsFields64 {
+    /// The *preferred* yet rarely provided address of the first byte of image when loaded into memory; must be a
+    /// multiple of 64 K.
+    ///
+    /// This address is rarely used because Windows uses memory protection mechanisms like Address Space Layout
+    /// Randomization (ASLR). As a result, it’s rare to see an image mapped to the preferred address. Instead,
+    /// the Windows PE Loader maps the file to a different address with an unused memory range. This process
+    /// would create issues because some addresses that would have been constant are now changed. The Loader
+    /// addresses this via a process called PE relocation which fixes these constant addresses to work with the
+    /// new image base. The relocation section (.reloc) holds data essential to this relocation process.
+    /// [Source](https://offwhitesecurity.dev/malware-development/portable-executable-pe/nt-headers/optional-header/).
+    ///
+    /// * The default address for DLLs is 0x10000000.
+    /// * The default for Windows CE EXEs is 0x00010000.
+    /// * The default for Windows NT, Windows 2000, Windows XP, Windows 95, Windows 98, and Windows Me is 0x00400000.
+    ///
+    /// ## Position in PE binary
+    ///
+    /// Windows fields are located inside [`OptionalHeader`] after [`StandardFields`] and before the
+    /// [`DataDirectories`](data_directories::DataDirectories).
+    ///
+    /// ## Related structures
+    ///
+    /// * For 32-bit version, see [`WindowsFields32`].
+    /// * For unified version, see [`WindowsFields`], especially the note on nominal equivalence.
+    #[doc(alias = "ImageBase")]
     pub image_base: u64,
+    /// Holds a byte value used for section alignment in memory.
+    ///
+    /// This value must be greater than or equal to
+    /// [`file_alignment`](WindowsFields64::file_alignment), which is the next field.
+    ///
+    /// When loaded into memory, sections are aligned in memory boundaries that are multiples of this value.
+    ///
+    /// If the value is less than the architecture’s page size, then the value should match
+    /// [`file_alignment`](WindowsFields64::file_alignment).
+    /// [Source](https://offwhitesecurity.dev/malware-development/portable-executable-pe/nt-headers/optional-header/).
+    ///
+    /// The default value is the page size for the architecture.
+    #[doc(alias = "SectionAlignment")]
     pub section_alignment: u32,
+    /// The alignment factor (in bytes) that is used to align the raw data of sections in the image file.
+    ///
+    /// The value should be a power of 2 between 512 and 64 K, inclusive.
+    ///
+    /// If the [`section_alignment`](WindowsFields64::section_alignment) is less than the architecture's page size,
+    /// then [`file_alignment`](WindowsFields64::file_alignment) must match [`section_alignment`](WindowsFields64::section_alignment).
+    ///
+    /// If [`file_alignment`](WindowsFields64::file_alignment) is less than [`section_alignment`](WindowsFields64::section_alignment),
+    /// then remainder will be padded with zeroes in order to maintain the alignment boundaries.
+    /// [Source](https://offwhitesecurity.dev/malware-development/portable-executable-pe/nt-headers/optional-header/).
+    ///
+    /// The default value is 512.
+    #[doc(alias = "FileAlignment")]
     pub file_alignment: u32,
+    /// The major version number of the required operating system.
+    #[doc(alias = "MajorOperatingSystemVersion")]
     pub major_operating_system_version: u16,
+    /// The minor version number of the required operating system.
+    #[doc(alias = "MinorOperatingSystemVersion")]
     pub minor_operating_system_version: u16,
+    /// The major version number of the image.
+    #[doc(alias = "MajorImageVersion")]
     pub major_image_version: u16,
+    /// The minor version number of the image.
+    #[doc(alias = "MinorImageVersion")]
     pub minor_image_version: u16,
+    /// The major version number of the subsystem.
+    #[doc(alias = "MajorSubsystemVersion")]
     pub major_subsystem_version: u16,
+    /// The minor version number of the subsystem.
+    #[doc(alias = "MinorSubsystemVersion")]
     pub minor_subsystem_version: u16,
+    /// Reserved, must be zero.
+    #[doc(alias = "Win32VersionValue")]
     pub win32_version_value: u32,
+    /// The size (in bytes) of the image, including all headers, as the image is loaded in memory.
+    ///
+    /// It must be a multiple of the [`section_alignment`](WindowsFields64::section_alignment).
+    #[doc(alias = "SizeOfImage")]
     pub size_of_image: u32,
+    /// The combined size of an MS-DOS stub, PE header, and section headers rounded up to a multiple of
+    /// [`file_alignment`](WindowsFields64::file_alignment).
+    #[doc(alias = "SizeOfHeaders")]
     pub size_of_headers: u32,
+    /// The image file checksum. The algorithm for computing the checksum is incorporated into IMAGHELP.DLL.
+    ///
+    /// The following are checked for validation at load time:
+    /// * all drivers,
+    /// * any DLL loaded at boot time, and
+    /// * any DLL that is loaded into a critical Windows process.
+    #[doc(alias = "CheckSum")]
     pub check_sum: u32,
+    /// The subsystem that is required to run this image.
+    ///
+    /// The subsystem can be one of the values in the [`goblin::pe::subsystem`](crate::pe::subsystem) module.
+    #[doc(alias = "Subsystem")]
     pub subsystem: u16,
+    /// DLL characteristics of the image.
+    ///
+    /// DLL characteristics can be one of the values in the
+    /// [`goblin::pe::dll_characteristic`](crate::pe::dll_characteristic) module.
+    #[doc(alias = "DllCharacteristics")]
     pub dll_characteristics: u16,
+    /// The size of the stack to reserve. Only [`WindowsFields::size_of_stack_commit`] is committed;
+    /// the rest is made available one page at a time until the reserve size is reached.
+    ///
+    /// In the context of memory management in operating systems, "commit" refers to the act of allocating physical memory
+    /// to back a portion of the virtual memory space.
+    ///
+    /// When a program requests memory, the operating system typically allocates virtual memory space for it. However,
+    /// this virtual memory space doesn't immediately consume physical memory (RAM) resources. Instead, physical memory
+    /// is only allocated when the program actually uses (or accesses) that portion of the virtual memory space.
+    /// This allocation of physical memory to back virtual memory is called "committing" memory.
+    #[doc(alias = "SizeOfStackReserve")]
     pub size_of_stack_reserve: u64,
+    /// The size of the stack to commit.
+    #[doc(alias = "SizeOfStackCommit")]
     pub size_of_stack_commit: u64,
+    ///  The size of the local heap space to reserve. Only [`WindowsFields::size_of_heap_commit`] is committed; the rest
+    /// is made available one page at a time until the reserve size is reached.
+    #[doc(alias = "SizeOfHeapReserve")]
     pub size_of_heap_reserve: u64,
+    /// The size of the local heap space to commit.
+    #[doc(alias = "SizeOfHeapCommit")]
     pub size_of_heap_commit: u64,
+    /// Reserved, must be zero.
+    #[doc(alias = "LoaderFlags")]
     pub loader_flags: u32,
+    /// The number of data-directory entries in the remainder of the optional header. Each describes a location and size.
+    #[doc(alias = "NumberOfRvaAndSizes")]
     pub number_of_rva_and_sizes: u32,
 }
 
+/// Convenience constant for `core::mem::size_of::<WindowsFields64>()`.
 pub const SIZEOF_WINDOWS_FIELDS_64: usize = 88;
-/// Offset of the `check_sum` field in [`WindowsFields64`]
+/// Offset of the `check_sum` field in [`WindowsFields64`].
 pub const OFFSET_WINDOWS_FIELDS_64_CHECKSUM: usize = 40;
 
 // /// Generic 32/64-bit Windows specific fields
@@ -358,9 +518,26 @@ impl TryFrom<WindowsFields64> for WindowsFields32 {
 //     }
 // }
 
+/// Unified 32/64-bit Windows fields (for `PE32` and `PE32+`). Since 64-bit fields are a superset of 32-bit fields,
+/// `WindowsFields` is an alias for `WindowsFields64`.
+//
+// Opinion (JohnScience): even though they're structurally equivalent, it was a questionable idea to make
+// them nominally equivalent as well because they're not actually the same thing semantically. WindowsFields is meant to be
+// a unified type that can represent either 32-bit or 64-bit Windows fields.
+//
+// How do you document this effectively and forward-compatibly? `WindowsFields64` and `WindowsFields` need
+// different documentation.
 pub type WindowsFields = WindowsFields64;
 
-/// Either 32 or 64-bit optional header.
+/// Unified 32/64-bit optional header (for `PE32` and `PE32+`).
+///
+/// Optional header is the most important of the [NT headers](https://offwhitesecurity.dev/malware-development/portable-executable-pe/nt-headers/).
+/// Although it's called "optional", it's actually required for PE image files.
+///
+/// It is meant to represent either
+///
+/// * [`IMAGE_OPTIONAL_HEADER32`](https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-image_optional_header32); or
+/// * [`IMAGE_OPTIONAL_HEADER64`](https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-image_optional_header64).
 ///
 /// Whether it's 32 or 64-bit is determined by the [`StandardFields::magic`] and by the value
 /// [`CoffHeader::size_of_optional_header`](crate::pe::header::CoffHeader::size_of_optional_header).
@@ -373,8 +550,11 @@ pub type WindowsFields = WindowsFields64;
 #[doc(alias = "IMAGE_OPTIONAL_HEADER32")]
 #[doc(alias = "IMAGE_OPTIONAL_HEADER64")]
 pub struct OptionalHeader {
+    /// Unified standard (COFF) fields. See [`StandardFields`] to learn more.
     pub standard_fields: StandardFields,
+    /// Unified Windows fields. See [`WindowsFields`] to learn more.
     pub windows_fields: WindowsFields,
+    /// Data directories. See [`DataDirectories`](data_directories::DataDirectories) to learn more.
     pub data_directories: data_directories::DataDirectories,
 }
 
@@ -388,6 +568,7 @@ pub const IMAGE_NT_OPTIONAL_HDR64_MAGIC: u16 = 0x20b;
 pub const IMAGE_ROM_OPTIONAL_HDR_MAGIC: u16 = 0x107;
 
 impl OptionalHeader {
+    /// Returns the container type of the PE binary.
     pub fn container(&self) -> error::Result<container::Container> {
         match self.standard_fields.magic {
             MAGIC_32 => Ok(container::Container::Little),

--- a/src/pe/subsystem.rs
+++ b/src/pe/subsystem.rs
@@ -1,0 +1,45 @@
+//! Constants for subsystems required to run image files. These constants are used in the
+//! [`goblin::pe::optional_header::WindowsFields::subsystem`](crate::pe::optional_header::WindowsFields::subsystem)
+//! field.
+
+/// An unknown subsystem.
+pub const IMAGE_SUBSYSTEM_UNKNOWN: u16 = 0;
+
+/// Device drivers and native Windows processes.
+pub const IMAGE_SUBSYSTEM_NATIVE: u16 = 1;
+
+/// The Windows graphical user interface (GUI) subsystem.
+pub const IMAGE_SUBSYSTEM_WINDOWS_GUI: u16 = 2;
+
+/// The Windows character subsystem.
+pub const IMAGE_SUBSYSTEM_WINDOWS_CUI: u16 = 3;
+
+/// The OS/2 character subsystem.
+pub const IMAGE_SUBSYSTEM_OS2_CUI: u16 = 5;
+
+/// The Posix character subsystem.
+pub const IMAGE_SUBSYSTEM_POSIX_CUI: u16 = 7;
+
+/// Native Win9x driver.
+pub const IMAGE_SUBSYSTEM_NATIVE_WINDOWS: u16 = 8;
+
+/// Windows CE.
+pub const IMAGE_SUBSYSTEM_WINDOWS_CE_GUI: u16 = 9;
+
+/// An Extensible Firmware Interface (EFI) application.
+pub const IMAGE_SUBSYSTEM_EFI_APPLICATION: u16 = 10;
+
+/// An EFI driver with boot services.
+pub const IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER: u16 = 11;
+
+/// An EFI driver with run-time services.
+pub const IMAGE_SUBSYSTEM_EFI_RUNTIME_DRIVER: u16 = 12;
+
+/// An EFI ROM image.
+pub const IMAGE_SUBSYSTEM_EFI_ROM: u16 = 13;
+
+/// XBOX.
+pub const IMAGE_SUBSYSTEM_XBOX: u16 = 14;
+
+/// Windows boot application.
+pub const IMAGE_SUBSYSTEM_WINDOWS_BOOT_APPLICATION: u16 = 16;


### PR DESCRIPTION
There's still some work needed for documentation of data directories field in the optional header but it's a separate module.

This PR also...
* introduces two new modules for constants that are used in the optional header (`dll_characteristic` and `subsystem`).
* further refines the documentation of the COFF header module.