### PR TITLE
PE: read reserved DOS header fields

### DIFF
--- a/src/pe/header.rs
+++ b/src/pe/header.rs
@@ -321,12 +321,10 @@ impl DosHeader {
         let initial_relative_cs = bytes.gread_with(&mut offset, scroll::LE)?;
         let file_address_of_relocation_table = bytes.gread_with(&mut offset, scroll::LE)?;
         let overlay_number = bytes.gread_with(&mut offset, scroll::LE)?;
-        let reserved = [0x0; 4];
-        offset += core::mem::size_of_val(&reserved);
+        let reserved = bytes.gread_with(&mut offset, scroll::LE)?; // 4
         let oem_id = bytes.gread_with(&mut offset, scroll::LE)?;
         let oem_info = bytes.gread_with(&mut offset, scroll::LE)?;
-        let reserved2 = [0x0; 10];
-        offset += core::mem::size_of_val(&reserved2);
+        let reserved2 = bytes.gread_with(&mut offset, scroll::LE)?; // 10
 
         debug_assert!(
             offset == PE_POINTER_OFFSET as usize,


### PR DESCRIPTION
This PR fixes `DosHeader::parse` by reading `reserved` and `reserved2` fields from the input instead of assuming that they are always zeros (PE64/32).

In the PECOFF, the DOS header fields except `e_lfanew` (the `pe_pointer` alias in the goblin) are entiely not read by the LDR (Windows loader). So assuming that the two fields in question does not really matter.

However, these fields are sometimes (and rarely) used by the PE packers for marking/watermaking purpose. In the real world example, Riot Games uses the `e_ss = 0x4952` and `e_sp = 0x544F` fields for `MZ ... RIOT` marker.