### PR TITLE
PE: TLS parser rework

### DIFF
--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -221,25 +221,15 @@ impl<'a> PE<'a> {
             }
 
             if let Some(tls_table) = optional_header.data_directories.get_tls_table() {
-                tls_data = if is_64 {
-                    tls::TlsData::parse_with_opts::<u64>(
-                        bytes,
-                        image_base,
-                        tls_table,
-                        &sections,
-                        file_alignment,
-                        opts,
-                    )?
-                } else {
-                    tls::TlsData::parse_with_opts::<u32>(
-                        bytes,
-                        image_base,
-                        &tls_table,
-                        &sections,
-                        file_alignment,
-                        opts,
-                    )?
-                };
+                tls_data = tls::TlsData::parse_with_opts(
+                    bytes,
+                    image_base,
+                    tls_table,
+                    &sections,
+                    file_alignment,
+                    opts,
+                    is_64,
+                )?;
                 debug!("tls data: {:#?}", tls_data);
             }
 

--- a/src/pe/tls.rs
+++ b/src/pe/tls.rs
@@ -45,27 +45,30 @@ pub struct TlsData<'a> {
 }
 
 impl ImageTlsDirectory {
-    pub fn parse<T: Sized>(
+    pub fn parse(
         bytes: &[u8],
         dd: data_directories::DataDirectory,
         sections: &[section_table::SectionTable],
         file_alignment: u32,
+        is_64: bool,
     ) -> error::Result<Self> {
-        Self::parse_with_opts::<T>(
+        Self::parse_with_opts(
             bytes,
             dd,
             sections,
             file_alignment,
             &options::ParseOptions::default(),
+            is_64,
         )
     }
 
-    pub fn parse_with_opts<T: Sized>(
+    pub fn parse_with_opts(
         bytes: &[u8],
         dd: data_directories::DataDirectory,
         sections: &[section_table::SectionTable],
         file_alignment: u32,
         opts: &options::ParseOptions,
+        is_64: bool,
     ) -> error::Result<Self> {
         let rva = dd.virtual_address as usize;
         let mut offset =
@@ -75,8 +78,6 @@ impl ImageTlsDirectory {
                     rva
                 ))
             })?;
-
-        let is_64 = core::mem::size_of::<T>() == 8;
 
         let start_address_of_raw_data = if is_64 {
             bytes.gread_with::<u64>(&mut offset, scroll::LE)?
@@ -115,39 +116,40 @@ impl ImageTlsDirectory {
 }
 
 impl<'a> TlsData<'a> {
-    pub fn parse<T: Sized>(
+    pub fn parse(
         bytes: &'a [u8],
         image_base: usize,
         dd: &data_directories::DataDirectory,
         sections: &[section_table::SectionTable],
         file_alignment: u32,
+        is_64: bool,
     ) -> error::Result<Option<Self>> {
-        Self::parse_with_opts::<T>(
+        Self::parse_with_opts(
             bytes,
             image_base,
             dd,
             sections,
             file_alignment,
             &options::ParseOptions::default(),
+            is_64,
         )
     }
 
-    pub fn parse_with_opts<T: Sized>(
+    pub fn parse_with_opts(
         bytes: &'a [u8],
         image_base: usize,
         dd: &data_directories::DataDirectory,
         sections: &[section_table::SectionTable],
         file_alignment: u32,
         opts: &options::ParseOptions,
+        is_64: bool,
     ) -> error::Result<Option<Self>> {
         let mut raw_data = None;
         let mut slot = None;
         let mut callbacks = Vec::new();
 
-        let is_64 = core::mem::size_of::<T>() == 8;
-
         let itd =
-            ImageTlsDirectory::parse_with_opts::<T>(bytes, *dd, sections, file_alignment, opts)?;
+            ImageTlsDirectory::parse_with_opts(bytes, *dd, sections, file_alignment, opts, is_64)?;
 
         // Parse the raw data if any
         if itd.end_address_of_raw_data != 0 && itd.start_address_of_raw_data != 0 {
@@ -176,6 +178,12 @@ impl<'a> TlsData<'a> {
                         rva
                     ))
                 })?;
+            if offset + size as usize > bytes.len() {
+                return Err(error::Error::Malformed(format!(
+                    "tls raw data offset ({:#x}) and size ({:#x}) greater than byte slice len ({:#x})",
+                    offset,size,bytes.len()
+                )));
+            }
             raw_data = Some(&bytes[offset..offset + size as usize]);
         }
 

--- a/src/pe/tls.rs
+++ b/src/pe/tls.rs
@@ -181,7 +181,7 @@ impl<'a> TlsData<'a> {
             if offset + size as usize > bytes.len() {
                 return Err(error::Error::Malformed(format!(
                     "tls raw data offset ({:#x}) and size ({:#x}) greater than byte slice len ({:#x})",
-                    offset,size,bytes.len()
+                    offset, size, bytes.len()
                 )));
             }
             raw_data = Some(&bytes[offset..offset + size as usize]);


### PR DESCRIPTION
- #433 

Changelists:
- Removed generics from `ImageTlsDirectory::parse*` and `TlsData::parse*`, instead added new argument `is_64` as proposed in the issue.
- Added slice bound check in `TlsData::raw_data` parser to compliant with panic-free design in goblin.

I personally prefer not making `ImageTlsDirectory32`―as it's more comfortable than the way duplicating the same kind of structs and merging to 64-bit as proposed in the issue.

This change should be marked as breaking-change and I expect this to be rolled up in 0.10.