### PR TITLE
build: expand targets for x64/x86 compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,62 +2,63 @@ name: CI
 on:
   push:
   pull_request:
-   branches:
-     - master
+    branches:
+      - master
 
 jobs:
   test:
     name: Test
-    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         build: [MSRV, stable, nightly, macos, win32, win64]
+        target:
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest } # Linux x64
+          - { target: i686-unknown-linux-gnu, os: ubuntu-latest } # Linux x86
+          - { target: x86_64-apple-darwin, os: macos-latest } # macOS x64
+          - { target: i686-pc-windows-msvc, os: windows-latest } # Windows x86
+          - { target: x86_64-pc-windows-msvc, os: windows-latest } # Windows x64
         include:
           - build: MSRV # Minimum supported Rust version
-            os: ubuntu-latest
             rust: 1.63.0
           - build: stable
-            os: ubuntu-latest
             rust: stable
           - build: nightly
-            os: ubuntu-latest
             rust: nightly
           - build: macos
-            os: macos-latest
             rust: stable
           - build: win32
-            os: windows-latest
-            rust: stable-i686-msvc
+            rust: stable
           - build: win64
-            os: windows-latest
-            rust: stable-x86_64-msvc
+            rust: stable
+    runs-on: ${{ matrix.target.os }}
     env:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
     steps:
-    - uses: actions/checkout@master
-    - name: Cache CARGO_HOME
-      uses: actions/cache@v1
-      with:
-        path: ~/.cargo
-        key: ${{ runner.os }}-cargo-home-${{ hashFiles('**/Cargo.toml') }}
-        restore-keys: ${{ runner.os }}-cargo-home
-    - name: Install Rust
-      shell: bash
-      run: |
-        curl -sSL https://sh.rustup.rs | sh -s -- -y --profile=minimal --default-toolchain=none
-        export PATH="$HOME/.cargo/bin:$PATH"
-        rustup override set ${{ matrix.rust }}
-        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-    - name: rustfmt
-      shell: bash
-      if: runner.os == 'Linux' && matrix.rust == 'stable'
-      run: |
-        rustup component add rustfmt
-        cargo fmt -- --check
-    - run: cargo build
-    - run: cargo build --all-targets
-    # FIXME: Looks like fuzzer cannot be run on Windows
-    - if: runner.os == 'Linux'
-      run: cargo build --manifest-path=fuzz/Cargo.toml
-    - run: cargo test
-    - run: make api
+      - uses: actions/checkout@master
+      - name: Cache CARGO_HOME
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo
+          key: ${{ runner.os }}-cargo-home-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: ${{ runner.os }}-cargo-home
+      - name: Install Rust
+        shell: bash
+        run: |
+          curl -sSL https://sh.rustup.rs | sh -s -- -y --profile=minimal --default-toolchain=none
+          export PATH="$HOME/.cargo/bin:$PATH"
+          rustup override set ${{ matrix.rust }}
+          rustup target add ${{ matrix.target.target }}
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - name: rustfmt
+        shell: bash
+        if: runner.os == 'Linux' && matrix.rust == 'stable'
+        run: |
+          rustup component add rustfmt
+          cargo fmt -- --check
+      - run: cargo build --target ${{ matrix.target.target }}
+      - run: cargo build --all-targets --target ${{ matrix.target.target }}
+      # FIXME: Looks like fuzzer cannot be run on Windows
+      - if: runner.os == 'Linux'
+        run: cargo build --manifest-path=fuzz/Cargo.toml --target ${{ matrix.target.target }}
+      - run: cargo test --target ${{ matrix.target.target }}
+      - run: make api


### PR DESCRIPTION
As I pointed out in [this comment](https://github.com/m4b/goblin/pull/426#discussion_r1855327540) and [the odd case](https://github.com/m4b/goblin/pull/426#discussion_r1848306592) there, I suggest expanding CI capabilities for explicit x64 and x86 host compatibility.

I'm always open to discuss how it should be done, instead of my proposal right here :).