### PR TITLE
pe.imports: ignore malformed imports in ParseMode::Permissive

### DIFF
--- a/src/pe/options.rs
+++ b/src/pe/options.rs
@@ -40,4 +40,9 @@ impl ParseOptions {
             parse_mode: ParseMode::Strict,
         }
     }
+
+    pub fn with_parse_mode(mut self, parse_mode: ParseMode) -> Self {
+        self.parse_mode = parse_mode;
+        self
+    }
 }


### PR DESCRIPTION
In some PE files one part of imports may be corrupted, but another part of imports is ok, and I want to be able parse this files
