### PR TITLE
pe.tls.tlsdata.parse_with_opts - integer overflow + out of bound

### DIFF
--- a/src/pe/tls.rs
+++ b/src/pe/tls.rs
@@ -227,7 +227,15 @@ impl<'a> TlsData<'a> {
                         rva
                     ))
                 })?;
-            if offset + size as usize > bytes.len() {
+
+            let offset_end = offset.checked_add(size as usize).ok_or_else(|| {
+                error::Error::Malformed(format!(
+                    "tls start_address_of_raw_data ({:#x}) + size_of_raw_data ({:#x}) casues an integer overflow",
+                    offset, size
+                ))
+            })?;
+
+            if offset > bytes.len() || offset_end > bytes.len() {
                 return Err(error::Error::Malformed(format!(
                     "tls raw data offset ({:#x}) and size ({:#x}) greater than byte slice len ({:#x})",
                     offset, size, bytes.len()


### PR DESCRIPTION
The check for the access of the bytes slice can be bypassed, by either a large 'offset' or using an integer overflow.  I attached the fuzzer test case to this post as well. 

[crash-37862deb65bdd4829ef254d5aabea5612f6453cc.zip](https://github.com/user-attachments/files/19397396/crash-37862deb65bdd4829ef254d5aabea5612f6453cc.zip)
