### PR TITLE
pe.options: added parse_tls_data option

### DIFF
--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -221,17 +221,19 @@ impl<'a> PE<'a> {
                 )?);
             }
 
-            if let Some(tls_table) = optional_header.data_directories.get_tls_table() {
-                tls_data = tls::TlsData::parse_with_opts(
-                    bytes,
-                    image_base,
-                    tls_table,
-                    &sections,
-                    file_alignment,
-                    opts,
-                    is_64,
-                )?;
-                debug!("tls data: {:#?}", tls_data);
+            if opts.parse_tls_data {
+                if let Some(tls_table) = optional_header.data_directories.get_tls_table() {
+                    tls_data = tls::TlsData::parse_with_opts(
+                        bytes,
+                        image_base,
+                        tls_table,
+                        &sections,
+                        file_alignment,
+                        opts,
+                        is_64,
+                    )?;
+                    debug!("tls data: {:#?}", tls_data);
+                }
             }
 
             if header.coff_header.machine == header::COFF_MACHINE_X86_64 {

--- a/src/pe/options.rs
+++ b/src/pe/options.rs
@@ -39,7 +39,7 @@ impl ParseOptions {
         Self {
             resolve_rva: false,
             parse_attribute_certificates: false,
-            parse_tls_data: false,
+            parse_tls_data: true,
             parse_mode: ParseMode::Strict,
         }
     }

--- a/src/pe/options.rs
+++ b/src/pe/options.rs
@@ -9,6 +9,7 @@ pub struct ParseOptions {
     /// memory](https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#other-contents-of-the-file).
     /// For on-disk representations, leave as true. Default: true
     pub parse_attribute_certificates: bool,
+    pub parse_tls_data: bool,
     /// Whether or not to end with an error in case of incorrect data or continue parsing if able. Default: ParseMode::Strict
     pub parse_mode: ParseMode,
 }
@@ -27,6 +28,7 @@ impl Default for ParseOptions {
         ParseOptions {
             resolve_rva: true,
             parse_attribute_certificates: true,
+            parse_tls_data: true,
             parse_mode: ParseMode::Strict,
         }
     }
@@ -37,6 +39,7 @@ impl ParseOptions {
         Self {
             resolve_rva: false,
             parse_attribute_certificates: false,
+            parse_tls_data: false,
             parse_mode: ParseMode::Strict,
         }
     }


### PR DESCRIPTION
Reason:
- sometimes I want to skip tls data parsing

Changes: 
- added `ParseOptions.parse_tls_data`