### PR TITLE
Handle Malformed/Obfuscated strtab Without UTF-8 Validation Error

### DIFF
--- a/src/strtab.rs
+++ b/src/strtab.rs
@@ -80,7 +80,13 @@ impl<'a> Strtab<'a> {
         let mut result = Self::from_slice_unparsed(bytes, offset, len, delim);
         let mut i = 0;
         while i < result.bytes.len() {
-            let string = get_str(i, result.bytes, result.delim)?;
+            let string = match get_str(i, result.bytes, result.delim) {
+                Ok(s) => s,
+                Err(_) => {
+                    // On error set to empty string
+                    ""
+                }
+            };
             result.strings.push((i, string));
             i += string.len() + 1;
         }


### PR DESCRIPTION
Hi everyone,

I encountered an issue while parsing malformed/obfuscated ELF files. Goblin tends to fail with a "bad input invalid UTF-8" error when it encounters non-valid UTF-8 strings in the `.strtab` section.

I believe this behavior isn't ideal, as we should still be able to parse these ELF files correctly even if the strings within `.strtab` aren't valid UTF-8. I think, there is no explicit requirement for the strings to be valid UTF-8 in strtab?

Here is an example of the kind of malformed input causing the issue:

```
    64: 0000000000000000     0 OBJECT  GLOBAL DEFAULT  UND __sF
    65: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND calloc
    66: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT  UND B|n5:Bn72FI?:#n[...]
    67: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT  UND B|n5:Bn72FI?:#n[...]
    68: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT  UND B|n5:Bn72FI?:#n[...]
    69: 000000000008cbfc  1950 FUNC    GLOBAL DEFAULT    1 p:z^I�^V^�9�^X3[...]
    70: 00000000000c41ea   434 FUNC    GLOBAL DEFAULT    1 ^�7,�j5!�j8#�P71[...]
    71: 00000000000c4118   435 FUNC    GLOBAL DEFAULT    1 ^\^��T^I)�X^I^T�[...]
    72: 00000000000c4137   432 FUNC    GLOBAL DEFAULT    1 �[@7^I"Y;�)S"O/E[...]
    73: 00000000000c4127   435 FUNC    GLOBAL DEFAULT    1 |7��i51�i8o�S7��[...]
```

Please find the attached binary as an example. As a temporary workaround, I simply replace invalid strings with an empty string (`""`) when parsing fails, but I don't think this is the most appropriate solution.

I'd like to open a discussion on how we should handle these cases. Should we consider skipping over invalid UTF-8 strings instead of failing, or is there another approach we’d prefer to implement?

Thanks a lot!

