### PR TITLE
pe.relocation.RelocationData.parse_with_opts - Possible out of bound

### DIFF
--- a/src/pe/relocation.rs
+++ b/src/pe/relocation.rs
@@ -347,6 +347,15 @@ impl<'a> RelocationData<'a> {
                         dd.virtual_address
                     ))
                 })?;
+        
+        // Ensure that the offset does not exceed the length of the bytes slice
+        if offset >= bytes.len() {
+            return Err(error::Error::Malformed(format!(
+                "base reloc offset {:#x} exceeds the bounds of the bytes size {:#x}",
+                offset, bytes.len()
+            )));
+        }
+
         let bytes = bytes[offset..]
             .pread::<&[u8]>(dd.size as usize)
             .map_err(|_| {

--- a/src/pe/relocation.rs
+++ b/src/pe/relocation.rs
@@ -347,12 +347,13 @@ impl<'a> RelocationData<'a> {
                         dd.virtual_address
                     ))
                 })?;
-        
+
         // Ensure that the offset does not exceed the length of the bytes slice
         if offset >= bytes.len() {
             return Err(error::Error::Malformed(format!(
                 "base reloc offset {:#x} exceeds the bounds of the bytes size {:#x}",
-                offset, bytes.len()
+                offset,
+                bytes.len()
             )));
         }
 


### PR DESCRIPTION
Found another possible out of bound memory access while fuzzing my project that uses goblin

[crash-6b996e5a1942c4b4d0156dac6616e087aff8f761.zip](https://github.com/user-attachments/files/20596524/crash-6b996e5a1942c4b4d0156dac6616e087aff8f761.zip)
