### PR TITLE
LoadConfig cannot read cb size fix

### DIFF
--- a/src/pe/load_config.rs
+++ b/src/pe/load_config.rs
@@ -337,7 +337,7 @@ impl LoadConfigData {
                     ))
                 })?;
         let bytes = bytes[offset..]
-            .pread::<&[u8]>(dd.size as usize)
+            .pread_with::<&[u8]>(0, dd.size as usize)
             .map_err(|_| {
                 error::Error::Malformed(format!(
                     "load config offset {:#x} and size {:#x} exceeds the bounds of the bytes size {:#x}",

--- a/src/pe/load_config.rs
+++ b/src/pe/load_config.rs
@@ -214,7 +214,7 @@ impl<'a> ctx::TryFromCtx<'a, Ctx> for LoadConfigDirectory {
         let is_64 = ctx.is_big();
         let mut offset = 0;
 
-        let mut read_arch_dependent_u64 = |offset: &mut usize| {
+        let read_arch_dependent_u64 = |offset: &mut usize| {
             if is_64 {
                 bytes.gread_with(offset, scroll::LE).ok()
             } else {
@@ -346,9 +346,7 @@ impl LoadConfigData {
                     bytes.len()
                 ))
             })?;
-        let size = bytes.pread::<u32>(0).map_err(|_| {
-            error::Error::Malformed(format!("cannot read cb size ({})", bytes.len()))
-        })?;
+
         let ctx = Ctx::new(
             if is_64 {
                 Container::Big


### PR DESCRIPTION
Hi guys, I think we have a typo here. I attached a binary as an example where it fails
[example.zip](https://github.com/user-attachments/files/20728727/example.zip)
