### PR TITLE
elf.note: added type_to_str support for coredump constants

### DIFF
--- a/src/elf/note.rs
+++ b/src/elf/note.rs
@@ -188,6 +188,15 @@ if_alloc! {
 
     impl<'a> Note<'a> {
         pub fn type_to_str(&self) -> &'static str {
+            // If the Note is from a coredump, match to different tags
+            if self.name == "CORE" {
+                return match self.n_type {
+                    NT_PRPSINFO => "NT_PRPSINFO",
+                    NT_PRSTATUS => "NT_PRSTATUS",
+                    NT_SIGINFO => "NT_SIGINFO",
+                    _ => "NT_UNKNOWN"
+                };
+            }
             match self.n_type {
                 NT_GNU_ABI_TAG => "NT_GNU_ABI_TAG",
                 NT_GNU_HWCAP => "NT_GNU_HWCAP",


### PR DESCRIPTION
I was trying to parse some coredumps with goblin, and got really confused when calling `type_to_str` because it didn't give me the coredump note constants that were in goblin. I noticed that although goblin had the common coredump constants, we aren't actually using it anywhere, so I thought it'd be nice to at least parse these constants properly in `type_to_str`