### PR TITLE
feat: add no-std error support

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,12 +2,13 @@
 //!
 
 use alloc::string::String;
+#[cfg(not(feature = "std"))]
+use core::error;
 use core::fmt;
 use core::num::TryFromIntError;
 use core::result;
 #[cfg(feature = "std")]
 use std::{error, io};
-
 #[non_exhaustive]
 #[derive(Debug)]
 /// A custom Goblin error
@@ -25,10 +26,10 @@ pub enum Error {
     BufferTooShort(usize, &'static str),
 }
 
-#[cfg(feature = "std")]
 impl error::Error for Error {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
+            #[cfg(feature = "std")]
             Error::IO(ref io) => Some(io),
             Error::Scroll(ref scroll) => Some(scroll),
             _ => None,

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,13 +2,10 @@
 //!
 
 use alloc::string::String;
-#[cfg(not(feature = "std"))]
 use core::error;
 use core::fmt;
 use core::num::TryFromIntError;
 use core::result;
-#[cfg(feature = "std")]
-use std::{error, io};
 #[non_exhaustive]
 #[derive(Debug)]
 /// A custom Goblin error
@@ -21,7 +18,7 @@ pub enum Error {
     Scroll(scroll::Error),
     /// An IO based error
     #[cfg(feature = "std")]
-    IO(io::Error),
+    IO(std::io::Error),
     /// Buffer is too short to hold N items
     BufferTooShort(usize, &'static str),
 }
@@ -38,8 +35,8 @@ impl error::Error for Error {
 }
 
 #[cfg(feature = "std")]
-impl From<io::Error> for Error {
-    fn from(err: io::Error) -> Error {
+impl From<std::io::Error> for Error {
+    fn from(err: std::io::Error) -> Error {
         Error::IO(err)
     }
 }


### PR DESCRIPTION
Currently, only the `std::error::Error` trait is implemented for custom goblin error. Therefore the crate cannot be used with e.g. thiserror in `no-std` environments. Causing this error:
```
error[E0599]: the method `as_dyn_error` exists for reference `&goblin::error::Error`, but its trait bounds were not satisfied
  --> uefi-loader/src/error.rs:42:12
   |
42 |     Goblin(#[from] goblin::error::Error),
   |            ^^^^^^^ method cannot be called on `&goblin::error::Error` due to unsatisfied trait bounds
   |
  ::: /home/hannah/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/goblin-0.10.0/src/error.rs:14:1
   |
14 | pub enum Error {
   | -------------- doesn't satisfy `goblin::error::Error: AsDynError<'_>` or `goblin::error::Error: core::error::Error`
   |
   = note: the following trait bounds were not satisfied:
           `goblin::error::Error: core::error::Error`
           which is required by `goblin::error::Error: AsDynError<'_>`
           `&goblin::error::Error: core::error::Error`
           which is required by `&goblin::error::Error: AsDynError<'_>`
``` 

 When the `std` feature is disabled, it is more practical to implement the `core::error::Error` trait instead. 