### PR TITLE
pe/load_config: guard slice indexing to prevent panic (Fixes #481)

### DIFF
--- a/src/pe/load_config.rs
+++ b/src/pe/load_config.rs
@@ -336,6 +336,15 @@ impl LoadConfigData {
                         dd.virtual_address
                     ))
                 })?;
+        // Ensure that the offset does not exceed the length of the bytes slice
+        if offset >= bytes.len() {
+            return Err(error::Error::Malformed(format!(
+                "load config offset {:#x} exceeds the bounds of the bytes size {:#x}",
+                offset,
+                bytes.len()
+            )));
+        }
+                
         let bytes = bytes[offset..]
             .pread_with::<&[u8]>(0, dd.size as usize)
             .map_err(|_| {


### PR DESCRIPTION
- Add bounds check to ensure the calculated offset doesn't exceed the input buffer size
- Improve error handling with descriptive error messages when bounds violations are detected
- Prevents potential crashes or undefined behavior when processing malicious or corrupted PE files
