### PR TITLE
PE: Expose load config data

### DIFF
--- a/src/pe/load_config.rs
+++ b/src/pe/load_config.rs
@@ -299,7 +299,7 @@ pub struct LoadConfigCodeIntegrity {
 #[derive(Debug, PartialEq, Clone, Default)]
 pub struct LoadConfigData {
     /// Parsed load config directory.
-    directory: LoadConfigDirectory,
+    pub directory: LoadConfigDirectory,
 }
 
 impl LoadConfigData {


### PR DESCRIPTION
`LoadConfigData::directory` was accidentally a private field in #464 (https://github.com/m4b/goblin/pull/464#issuecomment-2954702946) and it is inaccessible outside of the crate so I made it a `pub` field.