### PR TITLE
fix three PE resource parsing issues

### DIFF
--- a/src/pe/resource.rs
+++ b/src/pe/resource.rs
@@ -49,7 +49,10 @@ impl<'a> ctx::TryFromCtx<'a, scroll::Endian> for Utf16String<'a> {
     fn try_from_ctx(bytes: &'a [u8], _ctx: scroll::Endian) -> error::Result<(Self, usize)> {
         let len = bytes
             .chunks(2)
-            .take_while(|x| u16::from_le_bytes([x[0], x[1]]) != 0u16)
+            .take_while(|x| {
+                // Ensure chunk has at least 2 bytes before accessing x[1]
+                x.len() >= 2 && u16::from_le_bytes([x[0], x[1]]) != 0u16
+            })
             .count()
             * SIZE_OF_WCHAR;
         if len > bytes.len() {
@@ -169,7 +172,7 @@ impl<'a> ImageResourceDirectory {
     /// Returns the sum of [`ImageResourceDirectory::number_of_id_entries`] and [`ImageResourceDirectory::number_of_named_entries`]
     /// from the [`ImageResourceDirectory`].
     pub fn count(&self) -> u16 {
-        self.number_of_id_entries + self.number_of_named_entries
+        self.number_of_id_entries.saturating_add(self.number_of_named_entries)
     }
 
     /// Returns the total size of entries in bytes
@@ -386,11 +389,31 @@ impl ResourceEntry {
     where
         P: Fn(&Self) -> bool,
     {
+        const MAX_RECURSION_DEPTH: usize = 10; // PE resource directories typically have 3-4 levels (Type → Name/ID → Language → Data)
+        self.recursive_next_depth_with_limit(bytes, predicate, MAX_RECURSION_DEPTH)
+    }
+
+    /// Internal implementation with recursion depth limit
+    fn recursive_next_depth_with_limit<'a, P>(
+        &self,
+        bytes: &'a [u8],
+        predicate: P,
+        remaining_depth: usize,
+    ) -> error::Result<Option<ResourceEntry>>
+    where
+        P: Fn(&Self) -> bool,
+    {
+        if remaining_depth == 0 {
+            return Err(error::Error::Malformed(
+                "Maximum recursion depth exceeded in resource directory parsing".to_string(),
+            ));
+        }
+
         if let Some(next) = self.next_depth(bytes)? {
             if !predicate(&next) {
                 Ok(Some(next))
             } else {
-                next.recursive_next_depth(bytes, predicate)
+                next.recursive_next_depth_with_limit(bytes, predicate, remaining_depth - 1)
             }
         } else {
             Ok(Some(*self))

--- a/src/pe/resource.rs
+++ b/src/pe/resource.rs
@@ -389,7 +389,7 @@ impl ResourceEntry {
     where
         P: Fn(&Self) -> bool,
     {
-        const MAX_RECURSION_DEPTH: usize = 10; // PE resource directories typically have 3-4 levels (Type → Name/ID → Language → Data)
+        const MAX_RECURSION_DEPTH: usize = 10; 
         self.recursive_next_depth_with_limit(bytes, predicate, MAX_RECURSION_DEPTH)
     }
 


### PR DESCRIPTION
# Security Fixes for PE Resource Parsing

Three security vulnerabilities fixed in PE resource parsing that could crash applications with malformed files.

## 1. Index Out of Bounds - UTF-16 String Parsing
**Location:** `src/pe/resource.rs:52`

**Problem:** `bytes.chunks(2)` creates chunks with 1 element when input has odd length. Code accessed `x[1]` without checking if it exists.

**Crash Output:**
```
thread 'main' panicked at /private/tmp/fix_goblin/goblin/src/pe/resource.rs:52:55:
index out of bounds: the len is 1 but the index is 1
```

**Fix:** Check chunk length before accessing elements.
```rust
// Before
.take_while(|x| u16::from_le_bytes([x[0], x[1]]) != 0u16)

// After  
.take_while(|x| x.len() >= 2 && u16::from_le_bytes([x[0], x[1]]) != 0u16)
```

## 2. Integer Overflow - Resource Entry Count
**Location:** `src/pe/resource.rs:172`

**Problem:** Adding two `u16` values without overflow protection. Panics when sum exceeds `u16::MAX`.

**Crash Output:**
```
thread 'main' panicked at /private/tmp/fix_goblin/goblin/src/pe/resource.rs:172:9:
attempt to add with overflow
```

**Fix:** Use saturating addition.
```rust
// Before
self.number_of_id_entries + self.number_of_named_entries

// After
self.number_of_id_entries.saturating_add(self.number_of_named_entries)
```

## 3. Stack Overflow - Recursive Resource Parsing
**Location:** `src/pe/resource.rs:393`

**Problem:** No recursion depth limit. Malformed files with circular references cause infinite recursion.

**Crash Output:**
```
thread 'main' has overflowed its stack
fatal runtime error: stack overflow, aborting
zsh: abort      cargo run ../goblin_stackoverflow_poc.exe
```

**Fix:** Add 10-level recursion limit.
```rust
const MAX_RECURSION_DEPTH: usize = 10;

if remaining_depth == 0 {
    return Err(error::Error::Malformed(
        "Maximum recursion depth exceeded in resource directory parsing".to_string(),
    ));
}
```

Sets arbitrary recursion depth of 10 for safety margin.

POCs are included to trigger each error.
[pocs.zip](https://github.com/user-attachments/files/21940597/pocs.zip)
