### PR TITLE
Fixed getting section data tainted section lifetime

### DIFF
--- a/src/pe/section_table.rs
+++ b/src/pe/section_table.rs
@@ -99,7 +99,7 @@ impl SectionTable {
         Ok(table)
     }
 
-    pub fn data<'a, 'b: 'a>(&'a self, pe_bytes: &'b [u8]) -> error::Result<Option<Cow<'a, [u8]>>> {
+    pub fn data<'b>(&self, pe_bytes: &'b [u8]) -> error::Result<Option<Cow<'b, [u8]>>> {
         let section_start: usize = self.pointer_to_raw_data.try_into().map_err(|_| {
             Error::Malformed(format!("Virtual address cannot fit in platform `usize`"))
         })?;

--- a/src/pe/section_table.rs
+++ b/src/pe/section_table.rs
@@ -341,6 +341,19 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_section_to_bytes() {
+        let bytes = vec![0u8; 16];
+        let r_bytes = {
+            let mut section = SectionTable::default();
+            section.pointer_to_raw_data = 4;
+            section.size_of_raw_data = 4;
+            section.virtual_size = 4;
+            section.data(&bytes).unwrap().unwrap()
+        };
+        assert_eq!(*r_bytes, [0, 0, 0, 0])
+    }
+
+    #[test]
     fn set_name_offset() {
         let mut section = SectionTable::default();
         for &(offset, name) in [


### PR DESCRIPTION
Original lifetime specification was wrong and made the compiler think the returned lifetime had to live as long as the section data, which it did not.

Before the fix, the following code did not compile:

```rs
// ... open PE file
 let mut result = Vec::new();
 for section in pe.sections {
     result.push(section.data(file_bytes)); // compiler complains that section needs to live as long as result.
 }
 
 return result;
 ```
 
 After the fix getting section data can outlive the section.