### PR TITLE
PE: machinetypes - handle indeterminate types different from UNKNOWN

### DIFF
--- a/src/pe/header.rs
+++ b/src/pe/header.rs
@@ -1419,7 +1419,7 @@ pub fn machine_to_str(machine: u16) -> &'static str {
         COFF_MACHINE_SH5 => "SH5",
         COFF_MACHINE_THUMB => "THUMB",
         COFF_MACHINE_WCEMIPSV2 => "WCE_MIPS_V2",
-        _ => format!("Indeterminate machine type: {:X}", machine).as_str(),
+        _ => format!("Indeterminate machine type: {:X}", machine).as_str().into_static(),
     }
 }
 


### PR DESCRIPTION
this PR updates the machine type PE header to differentiate the UNKNOWN (0x0) machine type value and other, "indeterminate" PE machine types.

disclaimer: not a Rust dev

[NO_TRAIN]::