### PR TITLE
pe.options: added parse_resources option

### DIFF
--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -364,19 +364,18 @@ impl<'a> PE<'a> {
                 0
             };
 
-            if opts.parse_resources {
-                if let Some(&resource_table) = optional_header.data_directories.get_resource_table()
-                {
-                    let data = resource::ResourceData::parse_with_opts(
-                        bytes,
-                        resource_table,
-                        &sections,
-                        file_alignment,
-                        opts,
-                    )?;
-                    resource_data = Some(data);
-                    debug!("resource_data data: {:#?}", data.version_info);
-                }
+            if opts.parse_resources
+                && let Some(&resource_table) = optional_header.data_directories.get_resource_table()
+            {
+                let data = resource::ResourceData::parse_with_opts(
+                    bytes,
+                    resource_table,
+                    &sections,
+                    file_alignment,
+                    opts,
+                )?;
+                resource_data = Some(data);
+                debug!("resource_data data: {:#?}", data.version_info);
             }
 
             authenticode_excluded_sections = Some(authenticode::ExcludedSections::new(

--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -364,16 +364,19 @@ impl<'a> PE<'a> {
                 0
             };
 
-            if let Some(&resource_table) = optional_header.data_directories.get_resource_table() {
-                let data = resource::ResourceData::parse_with_opts(
-                    bytes,
-                    resource_table,
-                    &sections,
-                    file_alignment,
-                    opts,
-                )?;
-                resource_data = Some(data);
-                debug!("resource_data data: {:#?}", data.version_info);
+            if opts.parse_resources {
+                if let Some(&resource_table) = optional_header.data_directories.get_resource_table()
+                {
+                    let data = resource::ResourceData::parse_with_opts(
+                        bytes,
+                        resource_table,
+                        &sections,
+                        file_alignment,
+                        opts,
+                    )?;
+                    resource_data = Some(data);
+                    debug!("resource_data data: {:#?}", data.version_info);
+                }
             }
 
             authenticode_excluded_sections = Some(authenticode::ExcludedSections::new(

--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -378,22 +378,23 @@ impl<'a> PE<'a> {
                 0
             };
 
-            if opts.parse_resources
-                && let Some(&resource_table) = optional_header.data_directories.get_resource_table()
-            {
-                resource_data = resource::ResourceData::parse_with_opts(
-                    bytes,
-                    resource_table,
-                    &sections,
-                    file_alignment,
-                    opts,
-                )
-                .map(Some)
-                .or_permissive_and_default(
-                    opts.parse_mode.is_permissive(),
-                    "Failed to parse resource data",
-                )?;
-                debug!("resource_data data: {:#?}", resource_data);
+            if opts.parse_resources {
+                if let Some(&resource_table) = optional_header.data_directories.get_resource_table()
+                {
+                    resource_data = resource::ResourceData::parse_with_opts(
+                        bytes,
+                        resource_table,
+                        &sections,
+                        file_alignment,
+                        opts,
+                    )
+                    .map(Some)
+                    .or_permissive_and_default(
+                        opts.parse_mode.is_permissive(),
+                        "Failed to parse resource data",
+                    )?;
+                    debug!("resource_data data: {:#?}", resource_data);
+                }
             }
 
             authenticode_excluded_sections = Some(authenticode::ExcludedSections::new(

--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -378,7 +378,9 @@ impl<'a> PE<'a> {
                 0
             };
 
-            if let Some(&resource_table) = optional_header.data_directories.get_resource_table() {
+            if opts.parse_resources
+                && let Some(&resource_table) = optional_header.data_directories.get_resource_table()
+            {
                 resource_data = resource::ResourceData::parse_with_opts(
                     bytes,
                     resource_table,

--- a/src/pe/options.rs
+++ b/src/pe/options.rs
@@ -11,7 +11,10 @@ pub struct ParseOptions {
     /// memory](https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#other-contents-of-the-file).
     /// For on-disk representations, leave as true. Default: true
     pub parse_attribute_certificates: bool,
+    /// Whether or not to parse tls data. Default: true
     pub parse_tls_data: bool,
+    /// Whether or not to parse resources. Default: true
+    pub parse_resources: bool,
     /// Whether or not to end with an error in case of incorrect data or continue parsing if able. Default: ParseMode::Strict
     pub parse_mode: ParseMode,
 }
@@ -23,6 +26,7 @@ impl Default for ParseOptions {
             resolve_rva: true,
             parse_attribute_certificates: true,
             parse_tls_data: true,
+            parse_resources: true,
             parse_mode: ParseMode::Strict,
         }
     }
@@ -35,12 +39,23 @@ impl ParseOptions {
             resolve_rva: false,
             parse_attribute_certificates: false,
             parse_tls_data: true,
+            parse_resources: true,
             parse_mode: ParseMode::Strict,
         }
     }
 
     pub fn with_parse_mode(mut self, parse_mode: ParseMode) -> Self {
         self.parse_mode = parse_mode;
+        self
+    }
+
+    pub fn with_parse_tls_data(mut self, parse_tls_data: bool) -> Self {
+        self.parse_tls_data = parse_tls_data;
+        self
+    }
+
+    pub fn with_parse_resources(mut self, parse_resources: bool) -> Self {
+        self.parse_resources = parse_resources;
         self
     }
 }


### PR DESCRIPTION
Sometimes it's great to have a choice to skip resource parsing. Therefore, I added `ParseOptions.parse_resources`. Also, I decided to add a couple of missing `with_` methods to `ParseOptions`. 