### PR TITLE
pe: wrap ResourceData parse in or_permissive_and_default (follow-up to #508)

### DIFF
--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -40,7 +40,7 @@ use crate::pe::utils::pad;
 use crate::strtab;
 use options::ParseMode;
 
-use scroll::{Pwrite, ctx};
+use scroll::{ctx, Pwrite};
 
 use log::debug;
 
@@ -365,15 +365,19 @@ impl<'a> PE<'a> {
             };
 
             if let Some(&resource_table) = optional_header.data_directories.get_resource_table() {
-                let data = resource::ResourceData::parse_with_opts(
+                resource_data = resource::ResourceData::parse_with_opts(
                     bytes,
                     resource_table,
                     &sections,
                     file_alignment,
                     opts,
+                )
+                .map(Some)
+                .or_permissive_and_default(
+                    opts.parse_mode.is_permissive(),
+                    "Failed to parse resource data",
                 )?;
-                resource_data = Some(data);
-                debug!("resource_data data: {:#?}", data.version_info);
+                debug!("resource_data data: {:#?}", resource_data);
             }
 
             authenticode_excluded_sections = Some(authenticode::ExcludedSections::new(

--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -40,7 +40,7 @@ use crate::pe::utils::pad;
 use crate::strtab;
 use options::ParseMode;
 
-use scroll::{ctx, Pwrite};
+use scroll::{Pwrite, ctx};
 
 use log::debug;
 


### PR DESCRIPTION
Follow-up to #508. That PR added `or_permissive_and_default` inside `ResourceData::parse_with_opts` but the call site in `PE::parse()` still uses bare `?`:

```rust
// mod.rs line 367 — bare `?` means permissive mode doesn't help
let data = resource::ResourceData::parse_with_opts(
    bytes, resource_table, &sections, file_alignment, opts,
)?;
```

When `VersionInfo::parse` or `ManifestData::parse` fails inside that call (e.g. resource data RVAs that can't be mapped to file offsets), the error propagates through the bare `?` and kills the entire PE parse — even in `ParseMode::Permissive`.

This wraps it in `.map(Some).or_permissive_and_default(...)`, same as the debug_data, tls_data, load_config_data, and clr_data call sites nearby.

We hit this on packed PE malware (FSG, TELock) where the packer mangles the resource section but the rest of the PE is fine.