### PR TITLE
fix(elf): terminate NoteDataIterator after parse error to prevent infinite loop

### DIFF
--- a/src/elf/note.rs
+++ b/src/elf/note.rs
@@ -114,7 +114,13 @@ if_alloc! {
                 debug!("NoteIterator - {:#x}", self.offset);
                 match self.data.gread_with(&mut self.offset, self.ctx) {
                     Ok(res) => Some(Ok(res)),
-                    Err(e) => Some(Err(e))
+                    Err(e) => {
+                        // Terminate the iterator on parse error; without this,
+                        // offset stays unchanged and the same position is parsed
+                        // again on the next call, causing an infinite loop.
+                        self.offset = self.size;
+                        Some(Err(e))
+                    }
                 }
             }
         }
@@ -323,6 +329,24 @@ if_alloc! {
         fn ignore_no_sections() {
             let mut notes = NoteIterator { iters: vec![], index: 0 };
             assert!(notes.next().is_none());
+        }
+
+        #[test]
+        fn error_terminates_iterator() {
+            // Truncated data: only the first note header bytes, so parsing
+            // the name/desc will fail. The iterator must not loop infinitely;
+            // it must return an error once and then None on subsequent calls.
+            let truncated: &[u8] = &NOTE_DATA[..8]; // too short for a complete note
+            let mut iter = NoteDataIterator {
+                data: truncated,
+                size: truncated.len(),
+                offset: 0,
+                ctx: CONTEXT,
+            };
+            // First call: returns Some(Err(...))
+            assert!(iter.next().is_some_and(|r| r.is_err()));
+            // Second call: must return None, not loop
+            assert!(iter.next().is_none());
         }
     }
 }


### PR DESCRIPTION
Fixes #108.

`NoteDataIterator::next` calls `gread_with(&mut self.offset, ...)`. When
parsing fails, the scroll crate does not advance `self.offset` (it only
advances on success). The error arm returned `Some(Err(e))` without
updating `self.offset`, so the very next call to `next` sees the same
offset, parses the same bytes, hits the same error, and returns another
`Some(Err(e))` -- indefinitely. Callers like `.count()` or a plain
`for` loop that ignore the error arm never see `None` and hang forever.

The fix: set `self.offset = self.size` before returning the error, which
causes the termination check `self.offset >= self.size` to fire on the
very next call and return `None`.

A new unit test `error_terminates_iterator` verifies:
1. Parsing truncated data yields `Some(Err(_))` on the first call.
2. The second call returns `None` instead of repeating the error.

All existing tests continue to pass (`cargo test`).