### PR TITLE
fix(pe): skip indirect section names for PE images

### DIFF
--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -699,7 +699,7 @@ impl<'a> Coff<'a> {
         debug!("{:#?}", header);
         // TODO: maybe parse optional header, but it isn't present for Windows.
         *offset += header.size_of_optional_header as usize;
-        let sections = header.sections(bytes, offset)?;
+        let sections = header.sections_with_opts(bytes, offset, &crate::pe::options::ParseOptions::coff())?;
         let symbols = header.symbols(bytes)?;
         let strings = header.strings(bytes)?;
         Ok(Coff {

--- a/src/pe/options.rs
+++ b/src/pe/options.rs
@@ -17,6 +17,11 @@ pub struct ParseOptions {
     pub parse_resources: bool,
     /// Whether or not to end with an error in case of incorrect data or continue parsing if able. Default: ParseMode::Strict
     pub parse_mode: ParseMode,
+    /// Whether section names may use COFF indirect string table references (`/offset`).
+    ///
+    /// Indirect section names are only valid for COFF object files. PE images store section
+    /// names as UTF-8 in the 8-byte name field. Default: false
+    pub parse_indirect_section_names: bool,
 }
 
 impl Default for ParseOptions {
@@ -28,6 +33,7 @@ impl Default for ParseOptions {
             parse_tls_data: true,
             parse_resources: true,
             parse_mode: ParseMode::Strict,
+            parse_indirect_section_names: false,
         }
     }
 }
@@ -41,6 +47,14 @@ impl ParseOptions {
             parse_tls_data: true,
             parse_resources: true,
             parse_mode: ParseMode::Strict,
+            parse_indirect_section_names: false,
+        }
+    }
+
+    pub(crate) fn coff() -> Self {
+        Self {
+            parse_indirect_section_names: true,
+            ..Self::default()
         }
     }
 

--- a/src/pe/section_table.rs
+++ b/src/pe/section_table.rs
@@ -133,6 +133,10 @@ impl SectionTable {
         &self,
         opts: &crate::pe::options::ParseOptions,
     ) -> error::Result<Option<usize>> {
+        if !opts.parse_indirect_section_names {
+            return Ok(None);
+        }
+
         // Based on https://github.com/llvm-mirror/llvm/blob/af7b1832a03ab6486c42a40d21695b2c03b2d8a3/lib/Object/COFFObjectFile.cpp#L1054
         if self.name[0] == b'/' {
             let idx: usize = if self.name[1] == b'/' {
@@ -354,6 +358,31 @@ mod tests {
     }
 
     #[test]
+    fn pe_section_name_with_slash_is_not_indirect() {
+        let mut section = SectionTable::default();
+        section.name = *b"/1234567";
+        assert_eq!(
+            section
+                .name_offset_with_opts(&crate::pe::options::ParseOptions::default())
+                .unwrap(),
+            None
+        );
+        assert_eq!(section.name().unwrap(), "/1234567");
+    }
+
+    #[test]
+    fn coff_section_name_with_slash_is_indirect() {
+        let mut section = SectionTable::default();
+        section.name = *b"/1234567";
+        assert_eq!(
+            section
+                .name_offset_with_opts(&crate::pe::options::ParseOptions::coff())
+                .unwrap(),
+            Some(1_234_567)
+        );
+    }
+
+    #[test]
     fn set_name_offset() {
         let mut section = SectionTable::default();
         for &(offset, name) in [
@@ -368,7 +397,12 @@ mod tests {
         {
             section.set_name_offset(offset).unwrap();
             assert_eq!(&section.name, name);
-            assert_eq!(section.name_offset().unwrap(), Some(offset));
+            assert_eq!(
+                section
+                    .name_offset_with_opts(&crate::pe::options::ParseOptions::coff())
+                    .unwrap(),
+                Some(offset)
+            );
         }
         #[cfg(target_pointer_width = "64")]
         assert!(section.set_name_offset(0x1_000_000_000).is_err());


### PR DESCRIPTION
## Summary

- Add `parse_indirect_section_names` to `ParseOptions` (default: `false` for PE)
- Only resolve `/offset` and `//base64` COFF section name references when parsing COFF object files
- Enable indirect section name parsing for `Coff::parse` via `ParseOptions::coff()`

Fixes #487

## Test plan

- [x] `cargo test --lib pe::section_table::tests`
- [x] `cargo test --lib string_table_excludes_length`
- [x] New tests for PE literal `/1234567` names and COFF indirect parsing