### PR TITLE
fix: make elf32 and elf64 features additive (fixes #348)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,8 @@ default = [
 std = ["alloc", "scroll/std"]
 alloc = ["scroll/derive", "log"]
 endian_fd = ["alloc"]
-elf32 = []
-elf64 = []
+elf32 = ["elf64"]
+elf64 = ["elf32"]
 # for now we will require mach and pe to be alloc + endian_fd
 mach32 = ["alloc", "endian_fd", "archive"]
 mach64 = ["alloc", "endian_fd", "archive"]


### PR DESCRIPTION
## Summary

- Make `elf32` and `elf64` Cargo features mutually enable each other so selecting only one no longer breaks the build.

Fixes #348.

The ELF parser currently references both 32-bit and 64-bit modules in shared code paths. Requiring both features when either is enabled matches Cargo's additive feature guidance and avoids compile failures for users trimming dependencies.

Suggested approach from @d-e-s-o in the issue.

## Test plan

- [x] `cargo check --no-default-features --features "std,elf32"`
- [x] `cargo check --no-default-features --features "std,elf64"`
- [x] `cargo test --lib`