### PR TITLE
feat(mach): parse minimum macOS version from load commands (fixes #514)

### DIFF
--- a/src/mach/load_command.rs
+++ b/src/mach/load_command.rs
@@ -1068,6 +1068,41 @@ impl VersionMinCommand {
 
 pub const SIZEOF_VERSION_MIN_COMMAND: usize = 16;
 
+/// A macOS minimum version requirement from Mach-O load commands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MacOSVersion {
+    /// Major version (e.g. 10 in 10.15).
+    pub major: u16,
+    /// Minor version (e.g. 15 in 10.15).
+    pub minor: u16,
+}
+
+impl MacOSVersion {
+    /// Parse from a packed version used in `LC_BUILD_VERSION` and `LC_VERSION_MIN_MACOSX`.
+    ///
+    /// Format: `xxxx.yy.zz` where `x` is major, `y` is minor, and `z` is patch (ignored).
+    #[allow(clippy::cast_possible_truncation)]
+    pub const fn from_packed(packed: u32) -> Self {
+        Self {
+            major: ((packed >> 16) & 0xFFFF) as u16,
+            minor: ((packed >> 8) & 0xFF) as u16,
+        }
+    }
+}
+
+impl fmt::Display for MacOSVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}", self.major, self.minor)
+    }
+}
+
+impl VersionMinCommand {
+    /// Returns the minimum macOS version encoded in this load command.
+    pub fn macos_min_version(&self) -> MacOSVersion {
+        MacOSVersion::from_packed(self.version)
+    }
+}
+
 #[repr(C)]
 #[derive(Default, Debug, Clone, Copy, Pread, Pwrite, SizeWith)]
 pub struct DyldInfoCommand {
@@ -1202,6 +1237,17 @@ pub struct BuildVersionCommand {
     pub sdk: u32,
     /// number of tool entries following this
     pub ntools: u32,
+}
+
+impl BuildVersionCommand {
+    /// Returns the minimum macOS version if this load command targets macOS.
+    pub fn macos_min_version(&self) -> Option<MacOSVersion> {
+        if self.platform == PLATFORM_MACOS {
+            Some(MacOSVersion::from_packed(self.minos))
+        } else {
+            None
+        }
+    }
 }
 
 /// Build tool version
@@ -1856,5 +1902,67 @@ impl LoadCommand {
             offset: start,
             command,
         })
+    }
+}
+
+#[cfg(test)]
+mod macos_version_tests {
+    use super::*;
+
+    #[test]
+    fn from_packed_parses_major_minor() {
+        let version = MacOSVersion::from_packed(0x000A_0F00);
+        assert_eq!(version.major, 10);
+        assert_eq!(version.minor, 15);
+        assert_eq!(version.to_string(), "10.15");
+    }
+
+    #[test]
+    fn build_version_macos_platform() {
+        let cmd = BuildVersionCommand {
+            cmd: LC_BUILD_VERSION,
+            cmdsize: 24,
+            platform: PLATFORM_MACOS,
+            minos: 0x000B_0000,
+            sdk: 0,
+            ntools: 0,
+        };
+        assert_eq!(
+            cmd.macos_min_version(),
+            Some(MacOSVersion {
+                major: 11,
+                minor: 0
+            })
+        );
+    }
+
+    #[test]
+    fn build_version_non_macos_platform() {
+        let cmd = BuildVersionCommand {
+            cmd: LC_BUILD_VERSION,
+            cmdsize: 24,
+            platform: PLATFORM_IOS,
+            minos: 0x000E_0000,
+            sdk: 0,
+            ntools: 0,
+        };
+        assert_eq!(cmd.macos_min_version(), None);
+    }
+
+    #[test]
+    fn version_min_command_macos() {
+        let cmd = VersionMinCommand {
+            cmd: LC_VERSION_MIN_MACOSX,
+            cmdsize: SIZEOF_VERSION_MIN_COMMAND as u32,
+            version: 0x000A_0D00,
+            sdk: 0,
+        };
+        assert_eq!(
+            cmd.macos_min_version(),
+            MacOSVersion {
+                major: 10,
+                minor: 13
+            }
+        );
     }
 }

--- a/src/mach/mod.rs
+++ b/src/mach/mod.rs
@@ -146,6 +146,29 @@ impl<'a> MachO<'a> {
             Ok(vec![])
         }
     }
+    /// Returns the minimum macOS version required by this binary, if specified.
+    ///
+    /// Scans `LC_BUILD_VERSION` (platform macOS) and `LC_VERSION_MIN_MACOSX` load commands,
+    /// returning the highest minimum version found.
+    pub fn min_macos_version(&self) -> Option<load_command::MacOSVersion> {
+        use load_command::{CommandVariant, MacOSVersion, PLATFORM_MACOS};
+
+        let mut version = None;
+        for cmd in &self.load_commands {
+            match cmd.command {
+                CommandVariant::BuildVersion(ref build_ver) if build_ver.platform == PLATFORM_MACOS => {
+                    let v = MacOSVersion::from_packed(build_ver.minos);
+                    version = Some(version.map_or(v, |current| core::cmp::max(current, v)));
+                }
+                CommandVariant::VersionMinMacosx(ref ver) => {
+                    let v = MacOSVersion::from_packed(ver.version);
+                    version = Some(version.map_or(v, |current| core::cmp::max(current, v)));
+                }
+                _ => {}
+            }
+        }
+        version
+    }
     /// Parses the Mach-o binary from `bytes` at `offset`
     pub fn parse(bytes: &'a [u8], offset: usize) -> error::Result<MachO<'a>> {
         Self::parse_impl(bytes, offset, false)

--- a/src/mach/mod.rs
+++ b/src/mach/mod.rs
@@ -156,7 +156,9 @@ impl<'a> MachO<'a> {
         let mut version = None;
         for cmd in &self.load_commands {
             match cmd.command {
-                CommandVariant::BuildVersion(ref build_ver) if build_ver.platform == PLATFORM_MACOS => {
+                CommandVariant::BuildVersion(ref build_ver)
+                    if build_ver.platform == PLATFORM_MACOS =>
+                {
                     let v = MacOSVersion::from_packed(build_ver.minos);
                     version = Some(version.map_or(v, |current| core::cmp::max(current, v)));
                 }


### PR DESCRIPTION
## Summary

- Add `MacOSVersion` with `from_packed()` for Mach-O `xxxx.yy.zz` version encoding.
- Add `VersionMinCommand::macos_min_version()` and `BuildVersionCommand::macos_min_version()`.
- Add `MachO::min_macos_version()` scanning `LC_VERSION_MIN_MACOSX` and macOS `LC_BUILD_VERSION`, returning the highest minimum version found.

Fixes #514.

## Test plan

- [x] `cargo test macos_version`
- [x] `cargo test --lib`