### PR TITLE
pe: skip raw writes for virtual-only sections

### DIFF
--- a/src/pe/mod.rs
+++ b/src/pe/mod.rs
@@ -458,7 +458,13 @@ impl<'a> PE<'a> {
         );
 
         for section in &self.sections {
-            let section_data = section.data(&self.bytes)?.ok_or_else(|| {
+            if section.size_of_raw_data == 0 {
+                // Virtual-only sections, such as .bss, have no on-disk bytes to write.
+                bytes.gwrite_with(section, offset, ctx)?;
+                continue;
+            }
+
+            let section_data = section.data(self.bytes)?.ok_or_else(|| {
                 error::Error::Malformed(format!(
                     "Section data `{}` is malformed",
                     section.name().unwrap_or("unknown name")
@@ -865,7 +871,7 @@ mod tests {
 
     #[test]
     fn string_table_excludes_length() {
-        let coff = Coff::parse(&&COFF_FILE_SINGLE_STRING_IN_STRING_TABLE[..]).unwrap();
+        let coff = Coff::parse(&COFF_FILE_SINGLE_STRING_IN_STRING_TABLE[..]).unwrap();
         let string_table = coff.strings.unwrap().to_vec().unwrap();
 
         assert!(string_table == vec!["ExitProcess"]);
@@ -945,6 +951,81 @@ mod tests {
         assert!(
             permissive_result.is_ok(),
             "Permissive parsing should succeed for packed binary"
+        );
+    }
+
+    #[test]
+    fn write_sections_skips_virtual_only_section_data() {
+        const HEADER_SENTINEL: u8 = 0xA5;
+        const RAW_SECTION_OFFSET: usize = 0x80;
+        const SECTION_TABLE_OFFSET: usize = 0x100;
+        const RAW_SECTION_BYTES: &[u8] = b"raw!";
+
+        let source = {
+            let mut source = vec![0; RAW_SECTION_OFFSET + RAW_SECTION_BYTES.len()];
+            source[RAW_SECTION_OFFSET..RAW_SECTION_OFFSET + RAW_SECTION_BYTES.len()]
+                .copy_from_slice(RAW_SECTION_BYTES);
+            source
+        };
+        let pe = PE {
+            bytes: &source,
+            authenticode_excluded_sections: None,
+            header: header::Header::default(),
+            sections: vec![
+                section_table::SectionTable {
+                    name: *b".text\0\0\0",
+                    virtual_size: RAW_SECTION_BYTES.len() as u32,
+                    size_of_raw_data: RAW_SECTION_BYTES.len() as u32,
+                    pointer_to_raw_data: RAW_SECTION_OFFSET as u32,
+                    ..section_table::SectionTable::default()
+                },
+                section_table::SectionTable {
+                    name: *b".bss\0\0\0\0",
+                    virtual_size: 0x40,
+                    size_of_raw_data: 0,
+                    pointer_to_raw_data: 0,
+                    ..section_table::SectionTable::default()
+                },
+            ],
+            size: source.len(),
+            name: None,
+            is_lib: false,
+            is_64: true,
+            entry: 0,
+            image_base: 0,
+            export_data: None,
+            import_data: None,
+            exports: Vec::new(),
+            imports: Vec::new(),
+            libraries: Vec::new(),
+            debug_data: None,
+            tls_data: None,
+            exception_data: None,
+            relocation_data: None,
+            load_config_data: None,
+            certificates: Vec::new(),
+            resource_data: None,
+            clr_data: None,
+        };
+
+        let mut output = vec![HEADER_SENTINEL; SECTION_TABLE_OFFSET + 0x80];
+        let mut section_table_offset = SECTION_TABLE_OFFSET;
+
+        pe.write_sections(&mut output, &mut section_table_offset, None, scroll::LE)
+            .unwrap();
+
+        assert!(
+            output[..RAW_SECTION_OFFSET]
+                .iter()
+                .all(|byte| *byte == HEADER_SENTINEL)
+        );
+        assert_eq!(
+            &output[RAW_SECTION_OFFSET..RAW_SECTION_OFFSET + RAW_SECTION_BYTES.len()],
+            RAW_SECTION_BYTES
+        );
+        assert_eq!(
+            section_table_offset,
+            SECTION_TABLE_OFFSET + 2 * section_table::SIZEOF_SECTION_TABLE
         );
     }
 }

--- a/src/pe/section_table.rs
+++ b/src/pe/section_table.rs
@@ -100,28 +100,36 @@ impl SectionTable {
     }
 
     pub fn data<'b>(&self, pe_bytes: &'b [u8]) -> error::Result<Option<Cow<'b, [u8]>>> {
+        // Sections with no raw data are virtual-only in an on-disk PE.
+        if self.size_of_raw_data == 0 {
+            return Ok(None);
+        }
+
         let section_start: usize = self.pointer_to_raw_data.try_into().map_err(|_| {
-            Error::Malformed(format!("Virtual address cannot fit in platform `usize`"))
+            Error::Malformed("Virtual address cannot fit in platform `usize`".to_string())
         })?;
 
         // assert!(self.virtual_size <= self.size_of_raw_data);
         // if vsize > size_of_raw_data, the section is zero padded.
         let section_end: usize = section_start
             + usize::try_from(self.size_of_raw_data).map_err(|_| {
-                Error::Malformed(format!("Virtual size cannot fit in platform `usize`"))
+                Error::Malformed("Virtual size cannot fit in platform `usize`".to_string())
             })?;
 
-        let original_bytes = pe_bytes.get(section_start..section_end).map(Cow::Borrowed);
+        let original_bytes = match pe_bytes.get(section_start..section_end) {
+            Some(bytes) => bytes,
+            None => return Ok(None),
+        };
 
-        if original_bytes.is_some() && self.virtual_size > self.size_of_raw_data {
-            let mut bytes: Vec<u8> = Vec::new();
-            bytes.resize(self.size_of_raw_data.try_into()?, 0);
-            bytes.copy_from_slice(&original_bytes.unwrap());
-            bytes.resize(self.virtual_size.try_into()?, 0);
+        if self.virtual_size > self.size_of_raw_data {
+            let virtual_size = self.virtual_size.try_into()?;
+            let mut bytes = Vec::with_capacity(virtual_size);
+            bytes.extend_from_slice(original_bytes);
+            bytes.resize(virtual_size, 0);
 
             Ok(Some(Cow::Owned(bytes)))
         } else {
-            Ok(original_bytes)
+            Ok(Some(Cow::Borrowed(original_bytes)))
         }
     }
 
@@ -344,13 +352,28 @@ mod tests {
     fn test_section_to_bytes() {
         let bytes = vec![0u8; 16];
         let r_bytes = {
-            let mut section = SectionTable::default();
-            section.pointer_to_raw_data = 4;
-            section.size_of_raw_data = 4;
-            section.virtual_size = 4;
+            let section = SectionTable {
+                pointer_to_raw_data: 4,
+                size_of_raw_data: 4,
+                virtual_size: 4,
+                ..SectionTable::default()
+            };
             section.data(&bytes).unwrap().unwrap()
         };
         assert_eq!(*r_bytes, [0, 0, 0, 0])
+    }
+
+    #[test]
+    fn virtual_only_section_has_no_file_backed_data() {
+        let bytes = vec![0u8; 16];
+        let r_bytes = {
+            let section = SectionTable {
+                virtual_size: 16,
+                ..SectionTable::default()
+            };
+            section.data(&bytes).unwrap()
+        };
+        assert_eq!(r_bytes, None)
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- treat PE sections with `SizeOfRawData == 0` as virtual-only on disk
- preserve virtual-only section table entries while skipping nonexistent raw bytes during PE rewrite
- add synthetic regression coverage for the writer path without requiring an executable fixture

## Root cause

Some PE files, including the local Free Pascal sample used to reproduce this, contain a `.bss` section with a nonzero virtual size but no raw on-disk data. The writer previously expanded that virtual-only section into zero bytes and wrote them at `PointerToRawData == 0`, which could corrupt the DOS/PE headers.

## Validation

- `cargo fmt --check`
- `cargo test`
- focused virtual-only section regression tests
- touched-file strict Clippy filter
- local `freepascal_cli.exe` rewrite remained byte-identical by SHA256

## Notes

This is a narrow PE writer fix and does not special-case Free Pascal binaries. The regression test uses synthetic section data instead of adding a binary executable fixture.
